### PR TITLE
Automate stale-issue management and release-note generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# Configure automatically generated release notes
+#
+# Note that the order of categories is important, as they are rendered in the
+# order they are defined here. Each pull-request is assigned to the first
+# category that matches any of its labels. If no category matches, the pull
+# request is not included in the release notes.
+#
+# See <https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes>.
+
+changelog:
+  categories:
+    # This catch-all category ensures that no changes are omitted.
+    - title: ":tada: Contributions"
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+
+    # Finally, show dependency updates.
+    - title: ":dependabot: Dependencies"
+      labels:
+        - dependencies

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,54 @@
+# Stale Issue and Pull Request Management
+#
+# Automatically labels and closes inactive issues and pull requests to keep the
+# repository tidy. Runs daily at 03:32 UTC.
+#
+# Only assigned items are processed; unassigned items are pending triage.
+#
+# Pull requests: marked stale after 14 days, closed after 7 more days (21 total)
+# Issues: marked stale after 28 days, closed after 7 more days (35 total)
+#
+# Any activity (comment, commit, label change) resets the timer.
+
+name: "⏳ Stale"
+
+on:
+  workflow_dispatch:
+    inputs:
+      debug-only:
+        description: Debug only
+        type: boolean
+        default: true
+  schedule:
+    - cron: "32 3 * * *"
+
+permissions:
+  issues: write # Label and close stale issues
+  pull-requests: write # Label and close stale pull requests
+
+jobs:
+  stale:
+    name: Label & Close
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          stale-pr-message: |
+            This PR is stale because it has been open 14 days with no activity.
+
+            Remove the stale label or comment to keep it open, otherwise it will be closed in 7 days.
+          close-pr-message: This PR was closed because it has been inactive for 21 days.
+
+          days-before-issue-stale: 28
+          days-before-issue-close: 7
+          stale-issue-message: |
+            This issue is stale because it has been open 28 days with no activity.
+
+            Remove the stale label or comment to keep it open, otherwise it will be closed in 7 days.
+          close-issue-message: This issue was closed because it has been inactive for 35 days.
+
+          include-only-assigned: true
+
+          debug-only: ${{ github.event.inputs.debug-only || false }}


### PR DESCRIPTION
Assigned issues and PRs that go inactive are now labelled stale and eventually closed, keeping the tracker focused on active work. Unassigned items are exempt so that untriaged backlog is not prematurely discarded.

Release notes are auto-generated from merged PRs, splitting contributions from dependency updates via the `dependencies` label. This ensures every change is accounted for in the changelog without manual curation.

Closes #6