### PR TITLE
Define functional needs bridging concept of operations to requirements

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -117,17 +117,18 @@ rationale (traced to workflow), and acceptance sketch.
 
 - 5 files in `docs/needs/`
 - N-07 API Efficiency, N-08 Graceful Degradation, N-09 Target User Perspective,
-  N-10 Schema Evolution, N-11 Archive Integrity
-- N-11 captures the gap left by the absent validation workflow (W-04 in the
-  original plan). The archive must be internally consistent: blob references
-  resolve, snapshot manifests exist for all round SHAs, diff files are present.
-  Whether this is enforced as a W-01 postcondition or a standalone `validate`
-  command is a design decision for Phase 5; the need is agnostic to mechanism.
-  Traces to mission success criterion #1.
-- `docs: define supporting functional needs N-07 through N-11`
+  N-10 Schema Evolution, N-11 Archive Integrity Check
+- N-11 was re-scoped during drafting. The originally planned framing ("archive
+  must be internally consistent: blob references resolve, snapshot manifests
+  exist for all round SHAs, diff files are present") turned out to duplicate
+  N-06, which already mandates that every reference in the archive resolves to
+  data present in the archive. N-11 is therefore the _verification_ complement
+  to N-06: it names the capability of checking that the property N-06 asserts
+  actually holds on a given archive. A future `check` CLI subcommand is the
+  expected mechanism.
 - CRITICAL: commit each need separately
 - **Forward reference**: after creating N-09, update the `[n09]` link in
-  `docs/reference/00-original-conversation.md:169` to point at the new file.
+  `docs/reference/00-original-conversation.md` to point at the new file.
   Re-evaluate whether the influence map's characterisation still holds against
   the need as written.
 
@@ -263,12 +264,23 @@ documented.
 **Phase 0**: Complete (Steps 0.1–0.3). Reference docs committed, scaffold
 created, glossary established.
 
-**Phase 1**: Complete (Steps 1.1–1.5). Mission, actors, environment, W-01,
-W-02 committed. Original design conversation preserved with influence map.
+**Phase 1**: Complete (Steps 1.1–1.5). Mission, actors, environment, W-01, W-02
+committed. Original design conversation preserved with influence map.
 
-**Phase 2**: Next. Pull in the [original design conversation][conversation.json]
-(distilled in [00-original-conversation.md][conversation.md]) for fine details
-that inform needs. Commit each need separately.
+**Phase 2**: Complete. Steps 2.1 (N-01–N-06) and 2.2 (N-07–N-11) landed as
+separate commits per-need. N-11 was re-scoped during drafting from "archive
+integrity invariant" (which duplicated N-06) to "archive integrity check" (the
+verification capability that confirms N-06's invariant holds on an archive), as
+described in Step 2.2.
+
+**Phase 3**: Next. Pull in the reference docs (`reference/03` for schema,
+`reference/04` for API mapping, `reference/02` for storage layout) to derive the
+R-xxx requirements. Commit each requirement separately.
+
+Original Phase 2 sourcing note: the
+[original design conversation][conversation.json] (distilled in
+[00-original-conversation.md][conversation.md]) is the source for fine details
+not in the reference docs.
 
 [conversation.json]: docs/reference/00-design-conversation.json
 [conversation.md]: docs/reference/00-original-conversation.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,8 +10,8 @@ file; cross-references use bracket notation with relative links.
 | --------------- | ----------------------------------------------------- | --------- |
 | `reference/`    | Original design documents (read-only archive)         | —         |
 | `conops/`       | Concept of operations: actors, environment, workflows | W-nn      |
-| `needs/`        | Functional needs bridging ConOps to requirements      | N-nn      |
-| `requirements/` | Traceable requirements with V&V methods               | R-xxx-nn  |
+| `needs/`        | Functional needs bridging ConOps to requirements      | N-nn        |
+| `requirements/` | Traceable requirements with V&V methods               | R-nn[-STUB] |
 | `analysis/`     | Analysis documents resolving design questions         | A-nn      |
 | `decisions/`    | Numbered design decisions with rationale              | D-nn      |
 
@@ -19,12 +19,25 @@ file; cross-references use bracket notation with relative links.
 
 - **W-nn** — Workflow (e.g., W-01 Single-PR Export)
 - **N-nn** — Functional need (e.g., N-01 Review Round Reconstruction)
-- **R-xxx-nn** — Requirement, where `xxx` is the domain:
-  - `EXP` — Export pipeline
-  - `SCH` — Schema and data format
-  - `API` — GitHub API interaction
-  - `CLI` — CLI and user experience
-  - `STO` — Storage and archive structure
+- **R-nn[-STUB]** — Requirement. `nn` is a flat, universal sequence shared
+  across all requirements; areas do not have their own counters. An optional
+  `STUB` of up to 5 characters may follow the number to name the area the
+  requirement concerns, purely to aid scanning and group references — it is
+  not an enumeration, and areas need not partition cleanly. Favor short
+  vowel-dropped abbreviations that read as subject-matter nouns. Stubs
+  currently in use:
+  - `ARCHV` — archive-wide contracts: root layout, self-description,
+    schema version identifier, evolution policy
+  - `REVW`  — review rounds and their commits
+  - `THRD`  — comment threads
+  - `SNAP`  — HEAD snapshots and blob contents
+  - `DIFF`  — diffs between snapshots
+  - `API`   — GitHub API interaction: query patterns, rate limits, auth
+  - `CLI`   — CLI surface: subcommands, flags, output, exit codes
+  - `GAPS`  — completeness: strict mode, gap markers, abort contract
+  - `RPLY`  — self-contained replay: no out-of-band lookups
+  - `TRACE` — provenance: fields that let a consumer follow a datum to
+    its source
 - **A-nn** — Analysis document (e.g., A-01 Loose Comment Grouping)
 - **D-nn** — Design decision (e.g., D-01 Threads Belong to Rounds)
 

--- a/docs/needs/N-01-review-round-reconstruction.md
+++ b/docs/needs/N-01-review-round-reconstruction.md
@@ -1,0 +1,48 @@
+# N-01: Review Round Reconstruction
+
+## Statement
+
+The system shall reconstruct the sequence of review rounds conducted by the
+target user on a pull request, where each round represents a single review
+session anchored to the commit SHA the reviewer was looking at, the batch of
+feedback they produced, and the verdict (or absence of one) with which they
+concluded the session.
+
+## Rationale
+
+Rounds are the organising unit of the export. Every other captured artifact —
+threads, snapshots, diffs, gaps — is defined relative to a round, so the
+fidelity of round reconstruction governs the fidelity of the archive as a whole.
+Rounds are not supplied directly by the GitHub API; they are
+[constructed][round-construction] from reviews, comments, and timeline events.
+This constructive step is where the temporal structure of a real review session
+is recovered from the flat data GitHub exposes, and is the reason a bespoke
+export tool is needed at all.
+
+Traces to [W-01 §Round construction][w01-round] as the primary workflow step,
+and to [mission SC #3][sc] ("round construction accurately reflects the actual
+review sessions as they happened").
+
+## Acceptance Sketch
+
+The need is met when, for a given PR and target user, the export contains an
+ordered sequence of rounds in which:
+
+- Each round carries the snapshot SHA the reviewer was looking at, the review
+  verdict (or an explicit marker that none was submitted), and the
+  `submitted_at` timestamp that anchors it on the timeline.
+- The ordering of rounds matches the chronological order of the target user's
+  review submissions.
+- Feedback the target user authored outside a formal review (loose comments) is
+  either attributed to a round or explicitly recorded as unassigned — never
+  silently dropped.
+- A reviewer who submitted no reviews yields zero rounds without failing the
+  export.
+
+The choice of mechanism for loose-comment attribution is deferred to
+[A-01 Loose Comment Grouping][a-01] and is not part of this need.
+
+[round-construction]: ../glossary.md#domain-terms
+[w01-round]: ../conops/W-01-single-pr-export.md#round-construction
+[sc]: ../mission.md#success-criteria
+[a-01]: ../analysis/

--- a/docs/needs/N-02-thread-capture.md
+++ b/docs/needs/N-02-thread-capture.md
@@ -1,0 +1,51 @@
+# N-02: Thread Capture
+
+## Statement
+
+The system shall capture every review thread on the pull request as an anchored,
+chronologically ordered conversation: the location in code the thread discusses,
+the round in which it was born, the full sequence of comments exchanged by any
+participant, and the resolution state GitHub records for it.
+
+## Rationale
+
+Threads are where the substantive back-and-forth of a review lives: the initial
+objection, the developer's reply, the softened position, the acceptance with
+conditions. A training or evaluation dataset that omits this arc loses the
+reasoning structure the archive exists to preserve.
+
+Two properties of threads shape this need and distinguish it from N-01:
+
+- A thread belongs to the round in which it was initiated, not to the comments
+  within it. The conversation under a thread is timeless and may continue across
+  later rounds without the thread "moving." ([D-01][d-01])
+- The archive records only what GitHub knows (`is_resolved`, `is_outdated`) and
+  draws no inference about whether a resolved thread was actually addressed,
+  ignored, or resolved out-of-band. Thread realism — people crap all over
+  threads — is a property of the source data, not something the exporter tries
+  to clean up. ([D-02][d-02])
+
+Traces to [W-01 §Thread capture][w01-thread] and to [mission SC #2][sc]
+(downstream consumer can reconstruct the full review timeline: who said what, on
+which code, in what order).
+
+## Acceptance Sketch
+
+The need is met when, for a given PR:
+
+- Every review thread the PR carries appears in the archive, regardless of which
+  participant initiated it.
+- Each thread records the code location it discusses — file path, line position,
+  and the commit SHA the comment was originally placed on — so the thread
+  remains interpretable even after later force-pushes rewrite branch history.
+- Each thread records the originating round, or a null origin when the initiator
+  is not the target user.
+- Each thread contains its comments in chronological order, with the full body
+  of every comment and the author of each comment.
+- Each thread carries GitHub's resolution signals verbatim; the archive contains
+  no field that infers _why_ the thread was resolved, ignored, or left open.
+
+[d-01]: ../reference/05-glossary-and-decisions.md#1-threads-belong-to-rounds-comments-dont
+[d-02]: ../reference/05-glossary-and-decisions.md#2-no-inference-at-export-time
+[w01-thread]: ../conops/W-01-single-pr-export.md#thread-capture
+[sc]: ../mission.md#success-criteria

--- a/docs/needs/N-03-code-snapshot-preservation.md
+++ b/docs/needs/N-03-code-snapshot-preservation.md
@@ -1,0 +1,61 @@
+# N-03: Code Snapshot Preservation
+
+## Statement
+
+The system shall preserve the state of the code the target user was looking at
+during each round: for every round's snapshot SHA, the archive shall record the
+set of files that made up the reviewed surface and retain the content of those
+files, so that a downstream consumer can read any commented line in its
+surrounding file at the exact version the reviewer saw.
+
+## Rationale
+
+A comment anchored to `foo.go:142` only teaches what "good review" looks like
+when a consumer can read `foo.go` as it stood when the comment was placed.
+Without the snapshot, a thread is a disembodied remark; with it, the thread
+becomes an example of judgment exercised against real code.
+
+Snapshots also make the archive survive change in the outside world. GitHub will
+age out force-pushed commits, repositories get renamed, access tokens expire.
+The commitment that the archive be replayable with no GitHub API calls
+([mission SC #4][sc]) rests almost entirely on snapshots: everything else in the
+export — threads, rounds, diffs — is metadata; the file contents are the
+substrate those metadata point at.
+
+Two properties follow from the bronze-tier philosophy:
+
+- File contents are content-addressed by git blob SHA so that an unchanged file
+  across several rounds is stored once. Data duplication is acceptable at this
+  tier, but it should fall out of the data model, not be manufactured by the
+  exporter.
+- The reviewed surface includes both files changed in the PR and surrounding
+  context files that were unchanged. Context is what makes a comment
+  interpretable; how "surrounding" is scoped is an open analysis item
+  ([A-02][a-02]) and is not fixed by this need.
+
+Traces to [W-01 §Snapshot assembly][w01-snapshot] and
+[§Blob fetching][w01-blob], and to [mission SC #2][sc] (downstream consumer can
+reconstruct the full review timeline with complete file context at each round)
+and [mission SC #4][sc] (archive is self-contained).
+
+## Acceptance Sketch
+
+The need is met when, for every round recorded in the archive:
+
+- The archive carries a manifest for that round's snapshot SHA, listing every
+  file that makes up the reviewed surface with its path, change status, and a
+  reference to the content that file held at that SHA.
+- A consumer reading the archive offline can, given a thread's file and line,
+  retrieve the file's contents at the snapshot SHA of the round the thread was
+  born in, without any network call.
+- A file whose content has not changed between two snapshots in the same PR is
+  stored once and referenced from both manifests.
+- Files the exporter cannot or will not fetch in full (binary, oversized,
+  unreachable after force-push) are recorded in the manifest with an explicit
+  status that distinguishes them from files whose content is available — never
+  silently omitted.
+
+[sc]: ../mission.md#success-criteria
+[w01-snapshot]: ../conops/W-01-single-pr-export.md#snapshot-assembly
+[w01-blob]: ../conops/W-01-single-pr-export.md#blob-fetching
+[a-02]: ../analysis/

--- a/docs/needs/N-04-diff-generation.md
+++ b/docs/needs/N-04-diff-generation.md
@@ -1,0 +1,60 @@
+# N-04: Diff Generation
+
+## Statement
+
+The system shall make it possible, from the archive alone, to obtain the diff
+views that shape a reviewer's attention on a pull request: the diff between the
+PR's merge base and any round's snapshot, and the diff between any two round
+snapshots (not only consecutive rounds).
+
+## Rationale
+
+A reviewer's attention is guided by change. On the first round the reviewer
+scans the full PR diff; on every subsequent round they scan what the developer
+did since the last pass. Comments in later rounds frequently reference the
+inter-round delta implicitly ("you addressed the null check but the naming is
+still off"), and the archive cannot recover what "you addressed" refers to
+unless that delta is recoverable.
+
+Consecutive-round deltas are the common case, but they are not the only useful
+view. A consumer studying a multi-round negotiation may want to compare round 1
+against round 4 directly, skipping intermediate rounds that added and reverted
+noise. The archive should not force consumers to walk the chain.
+
+This need constrains _what the archive must make possible_, not _how_. The
+required diff views could be satisfied by several mechanisms:
+
+- storing precomputed patch files for each pair;
+- storing enough snapshots (the merge-base head plus each round's snapshot,
+  already captured by [N-03][n03]) that a consumer can compute any diff locally;
+- storing a minimal git database with the base commit plus the pushes between
+  rounds and tags identifying each round.
+
+Each option has different trade-offs in archive size, external tooling
+requirements, and robustness to force-push. Selecting among them is a design
+question to be resolved in a later analysis; this need captures what is known
+today — that the archive must _enable_ the diff views — without prescribing the
+mechanism.
+
+Traces to [W-01 §Diff generation][w01-diff] and to [mission SC #2][sc]
+(downstream consumer can reconstruct the full review timeline).
+
+## Acceptance Sketch
+
+The need is met when:
+
+- A consumer reading the archive offline can produce the diff from the PR's
+  merge base to any round's snapshot, using only data present in the archive.
+- A consumer reading the archive offline can produce the diff from any round's
+  snapshot to any other round's snapshot — not only consecutive pairs — using
+  only data present in the archive.
+- The merge-base commit and each round's snapshot commit are identifiable in the
+  archive (by SHA, at minimum) so the diffs are unambiguously named.
+- A round whose snapshot is unavailable (force-pushed away, unreachable at
+  export time) degrades consistently with the partial-data posture [N-03][n03]
+  establishes: diffs that depend on it are explicitly absent rather than
+  silently wrong.
+
+[w01-diff]: ../conops/W-01-single-pr-export.md#diff-generation
+[sc]: ../mission.md#success-criteria
+[n03]: N-03-code-snapshot-preservation.md

--- a/docs/needs/N-05-structured-archive-output.md
+++ b/docs/needs/N-05-structured-archive-output.md
@@ -25,7 +25,9 @@ captured, but a consumer has no reliable way to reach it.
 
 This need says that structure exists and is stable; it does not say what the
 structure is. The concrete filenames, directory layout, and field names belong
-to the [R-SCH][r-sch] and [R-STO][r-sto] requirements that follow from this
+to the [R-ARCHV][r-archv] requirements for archive-wide contracts and to the
+requirements for each captured entity ([R-REVW][r-revw], [R-THRD][r-thrd],
+[R-SNAP][r-snap], [R-DIFF][r-diff]) that follow from this
 need, informed by the existing [reference/02][ref02] and [reference/03][ref03]
 design documents.
 
@@ -53,7 +55,10 @@ The need is met when:
 
 [w01-archive]: ../conops/W-01-single-pr-export.md#archive-assembly
 [sc]: ../mission.md#success-criteria
-[r-sch]: ../requirements/
-[r-sto]: ../requirements/
+[r-archv]: ../requirements/
+[r-revw]: ../requirements/
+[r-thrd]: ../requirements/
+[r-snap]: ../requirements/
+[r-diff]: ../requirements/
 [ref02]: ../reference/02-directory-structure.md
 [ref03]: ../reference/03-schema-specification.md

--- a/docs/needs/N-05-structured-archive-output.md
+++ b/docs/needs/N-05-structured-archive-output.md
@@ -1,0 +1,59 @@
+# N-05: Structured Archive Output
+
+## Statement
+
+The system shall emit the export as a structured archive: a predictable layout
+of named, machine-readable resources in which the entities named by the other
+needs — rounds, threads, snapshots, diffs, file contents — are each reachable by
+a stable path and carry a stable shape.
+
+## Rationale
+
+Every consumer of the archive (downstream pipelines, fine-tuning jobs,
+evaluation harnesses, a future replay playground) is a program, not a person. A
+program needs three things the other needs do not guarantee on their own:
+
+- a **predictable layout**, so that reaching a resource does not require
+  guessing while scanning the archive;
+- **stable shapes**, so that a parser written today still works on archives
+  produced tomorrow (the export is the contract, not the code that wrote it);
+- **discoverability**, so that the full set of rounds, threads, snapshots, and
+  diffs in an archive can be enumerated without out-of-band knowledge.
+
+Without this need the other needs are satisfied only in principle: the data is
+captured, but a consumer has no reliable way to reach it.
+
+This need says that structure exists and is stable; it does not say what the
+structure is. The concrete filenames, directory layout, and field names belong
+to the [R-SCH][r-sch] and [R-STO][r-sto] requirements that follow from this
+need, informed by the existing [reference/02][ref02] and [reference/03][ref03]
+design documents.
+
+Traces to [W-01 §Archive assembly][w01-archive] and to [mission SC #1][sc] (the
+output conforms to a schema specification, and all referenced files exist in the
+archive).
+
+## Acceptance Sketch
+
+The need is met when:
+
+- The archive is a single self-described unit: opening it, a program can
+  determine the export's schema version and locate every resource the other
+  needs require, without consulting any out-of-band index.
+- Each kind of entity — PR metadata, rounds, threads, snapshots, diffs, file
+  contents — has one canonical location and one canonical shape within the
+  archive. Two archives produced by the same tool version are layout-identical
+  up to the data they carry.
+- The archive is read with general-purpose tooling (file-system traversal, JSON
+  parser, patch reader). No archive-specific binary format or custom parser is
+  required.
+- A consumer can enumerate all rounds of a PR, all threads on a PR, and all
+  snapshots of a round by reading the archive alone — no scan of unrelated
+  files, no inference from filename patterns beyond what the layout documents.
+
+[w01-archive]: ../conops/W-01-single-pr-export.md#archive-assembly
+[sc]: ../mission.md#success-criteria
+[r-sch]: ../requirements/
+[r-sto]: ../requirements/
+[ref02]: ../reference/02-directory-structure.md
+[ref03]: ../reference/03-schema-specification.md

--- a/docs/needs/N-06-self-contained-replay.md
+++ b/docs/needs/N-06-self-contained-replay.md
@@ -1,0 +1,60 @@
+# N-06: Self-Contained Replay
+
+## Statement
+
+The system shall produce archives that are self-contained: given only the files
+in the archive, a consumer shall be able to replay the target user's review of
+the pull request — the rounds, the threads, the code each comment was placed on,
+the diffs between rounds — without consulting GitHub, the original repository,
+or any other live service.
+
+## Rationale
+
+The closure property is the single acceptance test for the whole tool. It is the
+criterion the original design fixed as the **playground test**: an offline
+visualization that can render any past PR entirely from the exported data, with
+no API calls at render time ([reference/01 §Philosophy][ref01-philosophy]).
+Every other need in this directory describes one resource the archive must
+carry; this need describes the property the archive gains only when those
+resources are all present together.
+
+Self-containment is also what makes the archive outlive the world it was
+exported from. Repositories get renamed and deleted, access tokens expire,
+force-pushes age commits out, private repos go read-only. An archive that
+requires live GitHub access to interpret is not a bronze-tier dataset; it is a
+cache. Self-containment converts the cache into a permanent record.
+
+Two properties follow:
+
+- Every reference the archive contains (a commit SHA a thread is anchored to, a
+  blob SHA a snapshot manifest points at, an author login attached to a comment)
+  is either resolvable inside the archive or explicitly marked as unresolved.
+  There are no silent dangling pointers that only a GitHub call could follow.
+- Interpreting the archive requires no credentials. A consumer with the archive
+  on a laptop offline has access to everything a consumer with network access
+  would have.
+
+Traces to [mission SC #4][sc] (archive is self-contained: no GitHub API calls
+are needed to interpret any part of it) and to
+[W-01 §Archive assembly][w01-archive].
+
+## Acceptance Sketch
+
+The need is met when:
+
+- Every round, thread, snapshot, diff, and file reference in the archive
+  resolves to data present in the archive itself. Anything that cannot be
+  resolved is carried as an explicit gap marker (per the graceful-default
+  posture N-01..N-04 establish), not as a bare reference that a reader would
+  have to resolve out-of-band.
+- A consumer can render the full review timeline — who said what, on which code,
+  in what order, with the surrounding file contents — from the archive alone,
+  with no network access and no credentials.
+- The archive contains no URL, API endpoint, or external identifier that a
+  reader _must_ dereference to make sense of any captured datum. External
+  identifiers may appear as provenance (e.g., a GitHub node ID kept for
+  traceability), but the archive's meaning does not depend on resolving them.
+
+[ref01-philosophy]: ../reference/01-design-overview.md#philosophy
+[sc]: ../mission.md#success-criteria
+[w01-archive]: ../conops/W-01-single-pr-export.md#archive-assembly

--- a/docs/needs/N-07-api-efficiency.md
+++ b/docs/needs/N-07-api-efficiency.md
@@ -1,0 +1,70 @@
+# N-07: API Efficiency
+
+## Statement
+
+The system shall export a pull request within a bounded and predictable budget
+of GitHub API calls that scales with the pull request's shape (rounds, threads,
+unique files) rather than with naïve request counts, so that the archives the
+other needs describe remain attainable in practice and not only in principle.
+
+## Rationale
+
+The GitHub API is a shared, rate-limited resource. The user's `gh` token carries
+a single hourly budget (5 000 REST requests, 5 000 GraphQL points per
+[environment §Network Context][env-net]); every request the export issues is one
+the user cannot issue from anywhere else that hour. A tool that exhausts the
+budget on a single PR is not a tool the user will run twice.
+
+Three shapes of waste produce this outcome and this need exists to rule them
+out:
+
+- **Redundant file fetches across rounds.** Most files do not change between
+  rounds of a review. Fetching the same file five times because it appears in
+  five snapshots turns a 50-file PR into 250 requests for no additional
+  information. Content-addressed dedup by blob SHA is the natural remedy; the
+  need constrains the outcome (no redundant fetch), not the mechanism.
+- **Wrong API surface.** Threads fetched one REST comment at a time and stitched
+  via `in_reply_to_id` chains cost dozens of requests; the same data arrives in
+  one or two GraphQL queries ([reference/04 §Rate Limiting][ref04-rate]).
+  Choosing the efficient surface is not a performance optimisation — it is what
+  keeps the export within budget.
+- **No progress on retry.** When an export is interrupted mid-run (rate limit,
+  network blip), a naïve re-run starts over. Any data already captured in the
+  archive — especially blobs, which dominate the request count — should be
+  skipped on a subsequent run for the same PR.
+
+A supplementary mechanism is worth flagging here, even if this need does not
+mandate it: blob content need not arrive through the REST or GraphQL surface at
+all. A `git clone` or `git fetch` of the repository delivers every blob the
+export needs under a separate, much more permissive rate regime. Treating git as
+an alternative blob source — when the target repository is clonable under the
+authenticated user's credentials — collapses the dominant term in the API budget
+and is a legitimate avenue for satisfying this need. The choice of when and how
+to fall back to git is a later design question; the need leaves room for it.
+
+Traces to [environment §Network Context][env-net],
+[W-01 §Rate limit exhaustion][w01-rate], and
+[reference/04 §Rate Limiting Considerations][ref04-rate].
+
+## Acceptance Sketch
+
+The need is met when:
+
+- The number of API calls issued for a single-PR export scales with the PR's
+  shape (rounds × unique files + threads, roughly), not with `rounds × files` in
+  the worst case. A file whose content has not changed between two snapshots is
+  fetched once, not twice.
+- For a typical PR (a few rounds, tens of threads, tens of changed files,
+  bounded context scope) the export consumes a small fraction of the hourly API
+  budget — leaving headroom for other tools the user runs against the same
+  token.
+- Re-running the export for a PR whose previous run was interrupted does not
+  re-fetch blobs that were already written to the archive. The tool makes
+  progress toward completion on each run; it does not restart.
+- When GitHub exposes both REST and GraphQL surfaces for the same data, the
+  exporter uses the surface whose cost scales better with the volume of data —
+  not the one that happens to be simpler to call.
+
+[env-net]: ../conops/environment.md#network-context
+[w01-rate]: ../conops/W-01-single-pr-export.md#rate-limit-exhaustion
+[ref04-rate]: ../reference/04-api-mapping.md#rate-limiting-considerations

--- a/docs/needs/N-08-graceful-degradation.md
+++ b/docs/needs/N-08-graceful-degradation.md
@@ -1,0 +1,91 @@
+# N-08: Graceful Degradation
+
+## Statement
+
+The system shall produce a useful archive from partial data by default,
+recording every condition that prevented a referenced object from being captured
+as an explicit, machine-readable gap marker rather than as a silent omission or
+an export failure. A consumer opting into strict completeness (`--strict`) shall
+receive the opposite guarantee: the export succeeds only when no gap marker
+would be written, and fails otherwise.
+
+## Rationale
+
+Every other need in this directory describes what the archive carries when the
+world cooperates. This need describes what happens when the world does not. Real
+pull requests routinely produce partial data: force-pushes age out snapshot
+SHAs, the API size cap excludes large files, binary files are not reasonable to
+store inline, rate limits interrupt mid-run. A policy that refuses to produce
+any archive unless everything was retrieved would fail on the majority of real
+PRs; a policy that silently omits what could not be retrieved would corrupt the
+archive's meaning. Neither is acceptable, and neither is what this need calls
+for.
+
+### Why graceful is the default
+
+Graceful archives preserve strictly more information than strict ones. Whatever
+a strict run would emit, a graceful run emits as well — plus a labelled list of
+the gaps. A consumer who wants strictness can filter out any archive that
+carries a gap marker; a consumer who wants coverage cannot recover data that was
+never written. The default therefore serves the richer superset. It also aligns
+with the bronze-tier principle of capturing what GitHub knows, honestly and in
+full — including the fact that some things could not be known.
+
+The primary consumer named in [mission.md][mission-stakeholders], the data
+scientist training an LLM agent, benefits from coverage. Partial archives are
+still training signal; dropped archives are not.
+
+### What `--strict` is for
+
+Evaluation and ground-truth consumers have the opposite need. A validation set
+whose archives may quietly contain absent snapshots is not a reliable benchmark.
+For these consumers the `--strict` flag converts every gap condition into an
+export failure, so that any archive the tool produces is complete by
+construction. A strict archive needs no gap-aware reader; a graceful archive
+does.
+
+### What counts as a gap
+
+This need inherits gap conditions from the other needs rather than enumerating
+them exhaustively. In scope are, at minimum:
+
+- an unreachable snapshot SHA or any of its derived data ([N-03][n03],
+  [N-04][n04]);
+- a file whose content the exporter cannot or will not fetch in full (binary,
+  oversized, unreachable) ([N-03][n03]);
+- any condition subsequent needs and requirements introduce that would cause an
+  explicit "absent" marker to be written.
+
+The exhaustive list is established as the other needs and requirements land;
+this need supplies the dual-mode contract that wraps them all.
+
+Traces to [W-01 §Error Scenarios][w01-errors], to [mission SC #1][sc] (the
+output conforms to schema — gap markers must be schema-known), and to
+[mission SC #4][sc] (a graceful archive with explicit gap markers is still
+self-contained in the sense [N-06][n06] requires).
+
+## Acceptance Sketch
+
+The need is met when:
+
+- In the default mode, no failure to retrieve a referenced object causes the
+  export to abort. Every such failure is recorded in the archive as a typed,
+  machine-readable marker that a consumer can enumerate without heuristics.
+- Explicit gap markers are part of the archive's schema (not ad-hoc strings, not
+  omissions): a consumer written against the schema can distinguish a gap from a
+  present value without inference.
+- A graceful archive remains self-contained in the [N-06][n06] sense — gap
+  markers resolve to "this was missing, here is what is known about it" inside
+  the archive, not to a prompt for an API call.
+- `--strict` causes the export to fail — with a clear report of which conditions
+  triggered the failure — whenever any gap marker would have been written in the
+  default mode. An archive produced with `--strict` contains no gap markers.
+- The two modes produce the same archive whenever there are no gaps to record.
+  Strictness is a contract, not a different output shape.
+
+[mission-stakeholders]: ../mission.md#stakeholders
+[sc]: ../mission.md#success-criteria
+[w01-errors]: ../conops/W-01-single-pr-export.md#error-scenarios
+[n03]: N-03-code-snapshot-preservation.md
+[n04]: N-04-diff-generation.md
+[n06]: N-06-self-contained-replay.md

--- a/docs/needs/N-09-target-user-perspective.md
+++ b/docs/needs/N-09-target-user-perspective.md
@@ -1,0 +1,94 @@
+# N-09: Target User Perspective
+
+## Statement
+
+The system shall frame the archive around a single named **target user** and
+organise every captured artifact relative to that user's activity: rounds are
+the target user's review sessions, gaps are the intervals between them, and the
+negotiation arc within each thread is captured as the target user's judgment
+meeting the author's response.
+
+## Rationale
+
+A pull request is a multi-party conversation, but the archive gh-prexport
+produces is not a neutral transcript of it. It is a record of _one reviewer's
+craft_ — the standards they enforced, the feedback they gave, the positions they
+softened on and the ones they held. Flattening that into "all review activity on
+the PR" erases the thing the archive exists to preserve.
+
+This perspective is the reason the data model is shaped the way it is, as set
+out in the original design session ([reference/00 Turn 3][conv-turn3]):
+
+> My reviews often involve several "rounds". Each time I'd go on the GitHub UI,
+> place a review with many comments, sometimes even comment without a review (by
+> mistake mostly), and then submit without approval.
+
+"Rounds" as the fundamental unit ([N-01][n01]) only makes sense once there is a
+privileged participant whose sessions define them; the same activity by a
+co-reviewer would be other rounds in their own archive, not a merged stream in
+this one. The **"giving in" pattern** the same turn described — strong objection
+→ author pushback → softened position → acceptance with conditions — is likewise
+a property of one reviewer's arc across rounds, not a per-comment fact. The
+archive can only reconstruct it if it knows whose arc to follow.
+
+Per-user archives are also what makes later merging (the future [W-02][w02]
+workflow) meaningful: a repo-batch export is several target users' archives
+combined, each still interpretable in its own right, not a de-identified blend.
+
+Traces to [reference/01 §Purpose][ref01-purpose], the
+[glossary][glossary-domain] entry on _target user perspective_, and
+[reference/00 Turn 3][conv-turn3].
+
+## Acceptance Sketch
+
+The need is met when:
+
+- The archive names exactly one target user as a first-class, schema-known
+  entity, identifiable by a stable GitHub identifier (login plus node ID or
+  numeric ID), not inferred from file names or directory paths.
+- Rounds in the archive are the target user's review sessions only. Reviews,
+  review comments, or loose comments by other participants are still captured
+  where they belong to the archive's subject (for example as replies inside a
+  thread the target user initiated), but they do not constitute rounds.
+- Gaps between rounds are computed relative to the target user's `submitted_at`
+  timestamps, not to any other participant's activity.
+- Threads initiated by someone other than the target user have a null or
+  explicitly "other" round origin (per [N-02][n02]); they are recorded, but they
+  do not invent rounds that the target user did not conduct.
+- Two archives produced for the same PR but with different target users are
+  separately interpretable: each describes one reviewer's arc, and neither is a
+  subset of the other in its choice of rounds, gaps, or thread origins.
+
+## Future Evolution
+
+The framing above — one target user, always in the reviewer role — is a
+deliberate simplification. It matches the initial use case (a reviewer exports
+their own reviews to fine-tune an agent on their own craft) and its simplicity
+is a feature: it pins down what "round" means, who owns gaps, and whose arc the
+archive follows, without branching on role.
+
+As the tool sees more use and its archives meet more friction, this need is a
+likely place to revisit. Two extensions are already foreseeable:
+
+- **Author role.** A PR author's trajectory through a review — which feedback
+  they pushed back on, which they conceded, how their commits evolved between
+  rounds — is itself a training signal. A future version might allow the target
+  user to be the author instead, with rounds and gaps redefined relative to
+  pushes and replies rather than reviews.
+- **Multiple reviewers.** A PR reviewed by two or more senior reviewers carries
+  a multi-voice negotiation the per-user archive cannot capture. A future format
+  could hold several rounds streams in one archive, either by combining per-user
+  archives or by modelling round co-occurrence directly.
+
+Neither extension is in scope for v1, and neither should inform the schema v1
+decisions without concrete friction to motivate it. This section exists so that
+future work has an obvious place to attach itself when it arrives, and so that
+the current simplicity is not mistaken for an assertion that
+one-reviewer-one-archive is the final shape.
+
+[conv-turn3]: ../reference/00-original-conversation.md#turn-3-the-pivotal-correction-rounds
+[ref01-purpose]: ../reference/01-design-overview.md#purpose
+[glossary-domain]: ../glossary.md#domain-terms
+[n01]: N-01-review-round-reconstruction.md
+[n02]: N-02-thread-capture.md
+[w02]: ../conops/W-02-batch-and-merge.md

--- a/docs/needs/N-10-schema-evolution.md
+++ b/docs/needs/N-10-schema-evolution.md
@@ -29,7 +29,7 @@ evolution policy. Semantic versioning, date-stamped versions, or format-family
 labels like `single-pr` vs `repo-batch` are all permissible mechanisms; the need
 constrains the outcome (detectable, unambiguous, declared up front), not the
 convention. The specific labels and the transition policy belong to the
-[R-SCH][r-sch] requirements and the migrate/merge command that [W-02b][w02b]
+[R-ARCHV][r-archv] requirements and the migrate/merge command that [W-02b][w02b]
 introduces.
 
 Traces to [reference/01 §Versioning & Evolution][ref01-versioning],
@@ -63,4 +63,4 @@ The need is met when:
 [w02b]: ../conops/W-02-batch-and-merge.md#w-02b-merge-into-repo-batch-format
 [ref01-versioning]: ../reference/01-design-overview.md#versioning--evolution
 [sc]: ../mission.md#success-criteria
-[r-sch]: ../requirements/
+[r-archv]: ../requirements/

--- a/docs/needs/N-10-schema-evolution.md
+++ b/docs/needs/N-10-schema-evolution.md
@@ -1,0 +1,66 @@
+# N-10: Schema Evolution
+
+## Statement
+
+The system shall produce archives that identify their own schema version and
+format, so that a consumer can detect — before parsing any content — which shape
+the archive carries and refuse or adapt as appropriate. The schema shall be
+allowed to change across versions without ambiguity about which version a given
+archive belongs to.
+
+## Rationale
+
+The archive format defined today is not the archive format forever. The design
+already foresees at least two transitions: the move from a single-PR layout to
+the repo-batch format ([W-02][w02]), and refinements to individual files' shapes
+as gap markers, context scoping, and other questions from Phases 4–6 get
+resolved. Both will change what consumers see, and neither is avoidable.
+
+Bronze-tier discipline permits breaking schema changes — consumers that break
+should update to the new format — but it does not permit silent ones. The
+minimum a consumer needs from an archive is the ability to answer "which version
+of the schema is this?" before trusting any other field. Without that, a parser
+written for v1 will quietly misread a v2 archive, and the training data,
+evaluation data, or replay built on top will be wrong in ways nothing in the
+export will flag.
+
+This need therefore mandates a self-declared schema version, not a particular
+evolution policy. Semantic versioning, date-stamped versions, or format-family
+labels like `single-pr` vs `repo-batch` are all permissible mechanisms; the need
+constrains the outcome (detectable, unambiguous, declared up front), not the
+convention. The specific labels and the transition policy belong to the
+[R-SCH][r-sch] requirements and the migrate/merge command that [W-02b][w02b]
+introduces.
+
+Traces to [reference/01 §Versioning & Evolution][ref01-versioning],
+[W-02b §Merge into Repo-Batch Format][w02b], and to [mission SC #1][sc] (the
+output conforms to a schema specification — which specification must be knowable
+from the archive alone).
+
+## Acceptance Sketch
+
+The need is met when:
+
+- Every archive carries a schema version identifier at a well-known,
+  trivially-locatable position (a top-level file or root-level field) that a
+  consumer can read without parsing the rest of the archive.
+- The identifier distinguishes both the format family (e.g., single-PR versus
+  repo-batch) and the schema version within that family, so that consumers can
+  decide whether they understand the archive before reading it.
+- Two archives produced by the same tool version carry the same schema
+  identifier; archives produced by different tool versions that happen to emit
+  compatible content may share an identifier, but not by accident — version
+  equality is an explicit claim of compatibility, not a coincidence of output.
+- The version identifier is stable across the archive's lifetime: a consumer who
+  reads the identifier, caches it, and later re-reads the archive gets the same
+  answer. If a future tool rewrites an existing archive in place, it rewrites
+  the identifier too.
+- A consumer encountering an unknown schema version can refuse cleanly — the
+  identifier is sufficient to detect the mismatch — rather than producing
+  silent, partial, or wrong results.
+
+[w02]: ../conops/W-02-batch-and-merge.md
+[w02b]: ../conops/W-02-batch-and-merge.md#w-02b-merge-into-repo-batch-format
+[ref01-versioning]: ../reference/01-design-overview.md#versioning--evolution
+[sc]: ../mission.md#success-criteria
+[r-sch]: ../requirements/

--- a/docs/needs/N-11-archive-integrity-check.md
+++ b/docs/needs/N-11-archive-integrity-check.md
@@ -1,0 +1,67 @@
+# N-11: Archive Integrity Check
+
+## Statement
+
+The system shall provide a way to verify, against a single archive on disk, that
+every reference the archive makes to data inside itself resolves — and that
+every explicit gap marker is what the archive is permitted to carry in place of
+that data. The verification shall be executable without contacting GitHub.
+
+## Rationale
+
+[N-06][n06] names the property that every reference inside the archive resolves
+to data inside the archive. It does not provide the reader with a way to find
+out whether the property actually holds on a given archive. That affordance is
+what this need adds.
+
+The two needs are complementary:
+
+- **N-06 is the property.** It tells the exporter what to produce.
+- **N-11 is the verifier.** It tells the consumer how to check what was produced
+  before trusting it.
+
+A verifier is worth stating as its own need for two reasons. First, a consumer
+who did not run the exporter — a data scientist handed an archive by someone
+else, an evaluation harness reading archives from a shared store, a future
+playground loading an archive from a URL — has no standing to assume N-06 was
+satisfied; they need a way to check. Second, the verifier is also the test
+mechanism for the [N-08][n08] `--strict` contract: an archive produced with
+`--strict` should contain no gap markers, and an independent verifier is how a
+consumer confirms that claim without re-running the export.
+
+The verification is local to one archive. Cross-archive consistency (for
+example, checking that two archives produced for the same PR agree on round
+metadata) is a separate question that belongs to the future repo-batch workflows
+([W-02][w02]), not to this need.
+
+Traces to [N-06][n06] (the property being checked), [N-08][n08] (the
+graceful/strict contract the verifier reports against), and to the `check`
+subcommand described in the project memory that motivated this need.
+
+## Acceptance Sketch
+
+The need is met when:
+
+- The system exposes a verification capability that takes a single archive as
+  input and returns a pass/fail verdict plus a list of the conditions that
+  produced the verdict.
+- A passing archive has no reference that points at missing data, and every gap
+  marker it contains is one the schema defines as permitted in place of that
+  data.
+- A failing archive's report names each broken reference or disallowed gap
+  marker by its location in the archive, so a reader can find and investigate it
+  without guessing.
+- The verifier reads only the archive. It does not fetch anything from GitHub,
+  the original repository, or any external service to reach its verdict, so it
+  works on an archive whose source has since become unreachable.
+- An archive produced with `--strict` (per [N-08][n08]) passes the verifier only
+  if it contains zero gap markers; an archive produced in the default graceful
+  mode may pass the verifier while carrying gap markers, provided each one is
+  schema-permitted.
+- The verifier's pass verdict is a sufficient precondition for every downstream
+  consumer that assumes [N-06][n06]. Consumers do not have to re-implement
+  reference resolution to gain confidence in the archive.
+
+[n06]: N-06-self-contained-replay.md
+[n08]: N-08-graceful-degradation.md
+[w02]: ../conops/W-02-batch-and-merge.md

--- a/docs/reference/00-original-conversation.md
+++ b/docs/reference/00-original-conversation.md
@@ -31,7 +31,7 @@ jq -r '.chat_messages[5].content[] | select(.type=="thinking") | .thinking' \
 
 ## The Arc: 11 Turns in 13 Hours
 
-### Turn 1 — Is there an existing tool?
+### Turn 1: Is there an existing tool?
 
 > Is there an open source tool that scrapes my GitHub account for all my PR
 > comments and reviews and exports it so that I can fine tune LLM agents on it
@@ -42,7 +42,7 @@ a ~200-line Go CLI with `gh` as the auth layer, emitting JSONL of
 `(diff_hunk, comment)` pairs. This initial framing was flat and context-free;
 the conversation would reshape it entirely.
 
-### Turn 2 — What data matters?
+### Turn 2: What data matters?
 
 > What would be the most comprehensive list of information that is useful for
 > later use with LLMs to replicate and learn the user's code practices?
@@ -53,7 +53,7 @@ commit-level evolution, temporal/social context, and the "negative space" (what
 the reviewer did not comment on). The proposed `PRInteraction` record was
 comprehensive but temporally flat.
 
-### Turn 3 — The pivotal correction: rounds
+### Turn 3: The pivotal correction, rounds
 
 > This conceptual scheme doesn't reflect the relevant points in time. My reviews
 > often involves several "rounds". Each time I'd go on the GitHub UI, place a
@@ -73,7 +73,7 @@ pattern motivated the thread conversation model's preservation of the full arc
 across rounds, and later influenced [N-09][n09] (target user perspective) and
 the thread-round association model.
 
-### Turn 4 — Scope decisions
+### Turn 4: Scope decisions
 
 > Pure API for now, this is a GitHub CLI extension, developed with Go. The focus
 > of this project is on exporting data, no analysis yet. Data duplication is
@@ -87,7 +87,7 @@ philosophy (export not analysis), economics (storage is cheap), and the
 success criterion in [mission.md](../mission.md) and motivated the
 [Visualization Consumer](../conops/actors.md#visualization-consumer) actor.
 
-### Turn 5 — Thread realism
+### Turn 5: Thread realism
 
 > I still think you put too much into threads, people crap all over them. Some
 > people just resolve and forget to fix, others wait for the reviewer to
@@ -100,7 +100,7 @@ produced design decision D-02 (no inference at export time) in
 [reference/05][ref-05]: capture only what GitHub's API returns (`is_resolved`,
 `is_outdated`), leave interpretation to the analysis layer.
 
-### Turn 6 — Thread-round association
+### Turn 6: Thread-round association
 
 > It's ok to keep placeholders for some insights, like that resolution type.
 > Also, round is importantly but I think per thread rather than per comment.
@@ -110,7 +110,7 @@ A targeted structural correction: the round association belongs on the
 conversation under it is timeless. This became design decision D-01 (threads
 belong to rounds, comments don't) in [reference/05][ref-05].
 
-### Turn 7-8 — Format and the medallion model
+### Turn 7-8: Format and the medallion model
 
 > I agree with Directory tree with content-addressable blob store. This is the
 > "bronze tier" data (borrowed from the Medallion model of OLAP).
@@ -125,7 +125,7 @@ independent directory per PR, add a merge command later. This became D-06
 (single-PR export as atomic unit) and shaped
 [W-02](../conops/W-02-batch-and-merge.md).
 
-### Turn 9 — File splitting
+### Turn 9: File splitting
 
 > I wonder if there's value in keeping all threads as a single file, and all
 > rounds too. Consider both merging into existing/new files and splitting into
@@ -138,7 +138,7 @@ split: rounds stay in `pr.json` (always small), threads get their own
 `threads.json` (scales with discussion volume), and file contents are
 externalized to the blob store.
 
-### Turn 10 — Final corrections
+### Turn 10: Final corrections
 
 > Just to clarify on threads: comments don't logically "span" rounds. A thread
 > usually belongs to a specific review round [...] and the conversation belongs
@@ -150,7 +150,7 @@ Two final refinements: (1) thread conversations are timeless, not cross-round;
 `by_round`, `by_resolution`) rather than a file-keyed structure. The user also
 requested canonical GitHub IDs throughout (node IDs, numeric IDs).
 
-### Turn 11 — Artifact generation
+### Turn 11: Artifact generation
 
 > Generate artifacts in this Claude project so that we can reference this plan
 > more easily.

--- a/docs/reference/00-original-conversation.md
+++ b/docs/reference/00-original-conversation.md
@@ -179,4 +179,4 @@ How the conversation shaped the systems engineering artifacts:
 [ref-01]: 01-design-overview.md
 [ref-02]: 02-directory-structure.md
 [ref-05]: 05-glossary-and-decisions.md
-[n09]: ../needs/
+[n09]: ../needs/N-09-target-user-perspective.md


### PR DESCRIPTION
After this PR, gh-prexport's systems engineering documentation carries a full needs layer: eleven functional needs (N-01 through N-11) that name the capabilities the tool must provide, each traced back to a concept-of-operations workflow step and forward to a mission success criterion. This is Phase 2 of the INCOSE "vision to product" progression the repository adopted in notorious-ai/gh-prexport#12; the needs sit between the ConOps that PR established and the traceable requirements Phase 3 will derive from them. Without this layer, future requirements would have no traceable motivation: each R-nn must point upward at the capability it serves, and that capability is what these documents name.

The six core needs (N-01 Review Round Reconstruction through N-06 Self-Contained Replay) name the export capabilities that make a single-PR archive coherent. The five supporting needs (N-07 API Efficiency, N-08 Graceful Degradation, N-09 Target User Perspective, N-10 Schema Evolution, N-11 Archive Integrity Check) name the properties of how the export behaves, evolves, and can be trusted. Each need states the capability, the rationale with references to ConOps and mission, and an acceptance sketch that a future requirement can harden. Mechanism choices the needs depend on (loose-comment grouping, context-file scope, force-push handling) are deliberately deferred to the analysis documents Phase 4 will produce; the needs describe what must be true, not how.