### PR TITLE
Record existing design decisions in MADR format

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -214,9 +214,18 @@ Resolve the 6 open implementation questions from reference/04-api-mapping.md.
 
 ### Step 5.1 — Formalize existing decisions (D-01..10)
 
-- 10 files from reference/05 decisions, each with: status, date, context,
-  decision, alternatives, consequences, references
-- `docs: formalize design decisions D-01 through D-10`
+- 10 files from reference/05 decisions, written in MADR format: YAML frontmatter
+  for `status` and `date` (and `superseded-by` when `status: superseded`), body
+  sections for context, considered options, decision outcome, consequences, and
+  more information. The format convention itself lives in
+  `docs/decisions/README.md`
+- Reference/05's H3 subsections stay intact — they are prior work and remain the
+  archive of record for the original decision phrasing. Each commit adds a
+  single "Formalized as [D-nn][d-nn]." line at the end of the matching
+  subsection and a ref-style link definition, so readers of reference/05 are
+  pointed at the canonical MADR file without losing the original body
+- One commit per decision, retargeting any committed citation of that decision
+  in the same commit
 
 ### Step 5.2 — New decisions from analysis (D-11..14)
 
@@ -272,6 +281,15 @@ separate commits per-need. N-11 was re-scoped during drafting from "archive
 integrity invariant" (which duplicated N-06) to "archive integrity check" (the
 verification capability that confirms N-06's invariant holds on an archive), as
 described in Step 2.2.
+
+**Phase 5.1**: Complete ahead of Phase 3. D-01 through D-10 landed as separate
+commits in MADR format after `docs/decisions/README.md` was established as the
+format spec. Reference/05's original subsections are left intact; each commit
+only appends a "Formalized as [D-nn][d-nn]." line pointing at its canonical file
+and retargets the citations in N-02, `reference/00-original-conversation.md`,
+and the glossary. The reordering was driven by committed SE artifacts already
+citing D-01..D-10; the decisions directory is no longer empty under
+`docs/README.md`'s reading order.
 
 **Phase 3**: Next. Pull in the reference docs (`reference/03` for schema,
 `reference/04` for API mapping, `reference/02` for storage layout) to derive the

--- a/docs/decisions/D-01-threads-belong-to-rounds.md
+++ b/docs/decisions/D-01-threads-belong-to-rounds.md
@@ -1,0 +1,67 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-01: Threads belong to rounds, comments don't
+
+## Context and Problem Statement
+
+A review round is a single session in which the target user opens the PR at a
+specific commit, comments, and optionally submits a verdict. A thread is a
+conversation anchored to a code location, and the comments inside it can arrive
+from any participant at any time — the PR author's reply after the next push,
+the reviewer's follow-up two rounds later, and so on. The design must decide
+where the round association lives: on the individual comments, or on the thread
+as a whole.
+
+The question surfaced during the 3–4 April 2026 design conversation at
+[Turn 6][turn-6]: the initial draft attached a round identifier to every
+comment; the target user pushed back, observing that "round is important but I
+think per thread rather than per comment."
+
+## Considered Options
+
+- **Per-comment round association.** Every comment records the round in which it
+  was written. Round membership follows chronology exactly.
+- **Per-thread round association.** The thread records the round it was born in;
+  comments under it carry no round of their own.
+
+## Decision Outcome
+
+Chosen option: _per-thread round association_, because a thread is meaningful
+only relative to the round that opened it. Subsequent messages — a developer's
+reply, the reviewer's follow-up in a later round — are continuations of that
+conversation, not fresh participants in other rounds. Tagging each comment with
+a round misattributes replies to rounds they were never part of and fragments
+the thread's identity as a single arc.
+
+The conversation under a thread is therefore treated as timeless: comments
+appear in chronological order with authorship and timestamps, and the thread
+carries the round-of-origin as a first-class field.
+
+## Consequences
+
+- Threads become stable containers for discussion: a reader reconstructs "who
+  said what, on which code, in what order" without inferring round boundaries
+  comment-by-comment, which is exactly what [mission success criterion 2][sc]
+  asks for.
+- Developer replies and cross-round follow-ups no longer inflate later rounds
+  with content that did not originate there, keeping round-level reviewer
+  behaviour interpretable for downstream analysis.
+- Cross-round evolution of a thread (a reviewer softening position two rounds
+  later, for example) is recoverable only from comment timestamps and the commit
+  SHAs on individual comments, not from a round field on the comment. Tooling
+  that wants per-round slices of a thread computes them from those signals.
+- The thread's round-of-origin is null when the initiator is not the target
+  user, because the concept of a round is target-user-centric (see [N-02][n02]).
+
+## More Information
+
+- [Original design conversation, Turn 6 — Thread-round association][turn-6]
+- [N-02: Thread Capture][n02] — primary downstream consumer of this decision
+- [Mission success criterion 2][sc] — review timeline reconstruction
+
+[turn-6]: ../reference/00-original-conversation.md#turn-6-thread-round-association
+[n02]: ../needs/N-02-thread-capture.md
+[sc]: ../mission.md#success-criteria

--- a/docs/decisions/D-02-no-inference-at-export-time.md
+++ b/docs/decisions/D-02-no-inference-at-export-time.md
@@ -1,0 +1,75 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-02: No inference at export time
+
+## Context and Problem Statement
+
+Several GitHub-side signals in a pull request are structurally present but
+semantically thin. `is_resolved` on a thread says a button was clicked;
+`is_outdated` says a diff position no longer maps onto HEAD. Neither tells the
+consumer why — whether the concern was fixed, deferred, agreed away, or resolved
+verbally outside GitHub. Comment intent (suggestion, nit, blocking question) is
+similarly absent from the raw API. The export must decide whether to classify
+these signals at capture time or to stop at the raw surface.
+
+The question surfaced in the 3–4 April 2026 design conversation at
+[Turn 5][turn-5]. The initial draft introduced a `resolution_type` field
+populated by heuristic inference; the target user pushed back with "people crap
+all over [threads]", arguing that thread resolution is too noisy to classify
+honestly from the API alone.
+
+## Considered Options
+
+- **Infer at export.** The exporter runs heuristics against resolution, comment
+  phrasing, and diff state to populate semantic fields such as `resolution_type`
+  and comment intent labels.
+- **Capture only what the API returns; reserve inference fields as null
+  placeholders.** The schema keeps fields like `resolution_type` so a later
+  analysis layer can fill them, but the exporter never populates them.
+
+## Decision Outcome
+
+Chosen option: _capture only what the API returns, with null placeholders_,
+because inference at export time would bake the exporter's heuristics into the
+archive and make every consumer inherit them. Thread resolution semantics depend
+on context the API cannot see — verbal conversations, follow-up PRs, a
+reviewer's habit of resolving-and-forgetting — and any classification will be
+wrong often enough to corrupt the dataset it is meant to seed.
+
+Placeholders remain in the schema so downstream analysis tools have idiomatic
+slots to write into; the boundary between raw capture and analysis is drawn at
+the export tool's edge.
+
+## Consequences
+
+- The archive is faithful to what GitHub knows. Mission scope explicitly
+  excludes "analysis, inference, or scoring of review quality" and "resolution
+  inference"; this decision is what makes that boundary enforceable at the data
+  layer (see [mission scope][mission-scope]).
+- The same philosophy generalises to [graceful degradation][n08]: when data is
+  missing, the archive records the absence rather than guessing the missing
+  value. Honesty about what is and is not known is a property of the whole
+  bronze tier.
+- Consumers that want resolution classification, comment intent labels, or
+  similar enrichment must build a silver-tier transformation. The archive gives
+  them stable inputs; it does not give them the labels.
+- Schema evolution can add new placeholder fields without breaking existing
+  consumers, because the rule "placeholders are null at export" is the invariant
+  rather than the specific field list.
+
+## More Information
+
+- [Original design conversation, Turn 5 — Thread realism][turn-5]
+- [N-02: Thread Capture][n02] — consumes this decision for thread resolution
+  handling
+- [N-08: Graceful Degradation][n08] — shares the "record absence, do not guess"
+  principle
+- [Mission scope][mission-scope] — classification and inference are out of scope
+
+[turn-5]: ../reference/00-original-conversation.md#turn-5-thread-realism
+[n02]: ../needs/N-02-thread-capture.md
+[n08]: ../needs/N-08-graceful-degradation.md
+[mission-scope]: ../mission.md#scope

--- a/docs/decisions/D-03-data-duplication-over-normalization.md
+++ b/docs/decisions/D-03-data-duplication-over-normalization.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-03: Data duplication over normalization
+
+## Context and Problem Statement
+
+Several pieces of data have natural homes in multiple places. A diff hunk is
+relevant on the thread it anchors (`original_diff_hunk`), on each individual
+comment posted within that thread (`diff_hunk_at_time`), and as a standalone
+patch file under `diffs/`. A consumer reading only a thread should know which
+hunk the conversation is about; a consumer replaying a round should get the full
+diff without opening per-comment payloads; a consumer applying patches should
+get a clean `.patch` file. The design must decide whether to inline the data at
+each site or normalize it behind a single source of truth with references.
+
+## Considered Options
+
+- **Normalize with references.** Diffs live in one canonical location (the patch
+  file, or a keyed registry); threads and comments carry only the key needed to
+  join back.
+- **Duplicate intentionally.** Each access site carries its own full copy of the
+  hunk; consumers never need to cross-reference files for basic operations.
+
+## Decision Outcome
+
+Chosen option: _duplicate intentionally_, because the archive's purpose is to be
+read by independent consumers, each with a different access pattern, and
+requiring every consumer to implement cross-file joins defeats the
+self-containment property the archive is built for. The storage cost is trivial
+compared to blob contents; the ergonomic cost of normalization would be paid on
+every query.
+
+## Consequences
+
+- Reading a thread in `threads.json` gives a consumer everything it needs about
+  that thread — including the diff being discussed — without opening any other
+  file. The same applies to per-comment records and to standalone patches.
+- This is the structural mechanism behind [N-06: Self-Contained Replay][n06]:
+  every in-archive reference resolves inside the archive without a join across
+  files being _required_ for basic interpretation.
+- Because the export is write-once and immutable, the identical-looking copies
+  cannot drift. The "single source of truth" argument for normalization does not
+  apply here; the hazard it guards against cannot occur.
+- The archive is larger than a normalized form would produce. This is the
+  accepted trade: storage is cheap, consumer ergonomics are not.
+- Consumers reading the schema must understand that the same hunk appearing in
+  multiple locations is intentional. The schema documentation in
+  [reference/03][ref-03] names each location explicitly.
+
+## More Information
+
+- [Reference/03 — schema specification][ref-03] for the field-level layout of
+  the duplicated hunk sites
+- [N-06: Self-Contained Replay][n06] — consumes this decision directly
+
+[ref-03]: ../reference/03-schema-specification.md
+[n06]: ../needs/N-06-self-contained-replay.md

--- a/docs/decisions/D-04-blobs-for-file-contents.md
+++ b/docs/decisions/D-04-blobs-for-file-contents.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-04: Blobs for file contents, inline for everything else
+
+## Context and Problem Statement
+
+The archive carries data with very different storage characteristics. File
+contents are bulky and repeat across snapshots: a single unchanged file may
+appear in five rounds with identical bytes. Thread conversations, comments,
+round metadata, and indexes are comparatively tiny and do not repeat — every
+comment is unique to its thread. A blanket policy of "externalize everything
+large" or "keep everything inline" ignores this split and either fragments small
+data into blobs or forces large data through JSON.
+
+## Considered Options
+
+- **Inline everything.** File contents, diffs, and metadata all live inside JSON
+  documents.
+- **Externalize file contents only.** File contents go to a content-addressed
+  blob store; diffs, comments, metadata, and thread conversations stay in their
+  respective JSON files.
+- **Externalize anything potentially large.** File contents, large diffs, and
+  long comment bodies are all blobbed.
+
+## Decision Outcome
+
+Chosen option: _externalize file contents only_, because the split follows the
+data. File contents dominate archive storage and deduplicate naturally — the
+same file appears across multiple snapshots and gets stored once when keyed by
+git blob SHA. Everything else is small, non-deduplicable, and more useful inline
+where consumers already expect to find it.
+
+Diffs are not blobs either; they are plain `.patch` files on disk. That choice
+is made by the next decision in this series, which addresses their specific
+tool-compatibility concerns.
+
+## Consequences
+
+- The blob store is the archive's only content-addressed surface. Every other
+  file is navigable by path and readable as-is. This keeps the mental model
+  simple: JSON for structure, blobs for file bytes, patches for diffs.
+- File-content deduplication is automatic and scales with how much code stays
+  stable across rounds. The "blob dominates storage" assumption only strengthens
+  as the number of rounds grows.
+- [N-03: Code Snapshot Preservation][n03] gets the efficient path it needs
+  without pulling every snapshot into JSON. Snapshot manifests reference blob
+  SHAs; consumers fetch by SHA when they need bytes.
+- Inline JSON stays navigable with standard tools (`jq`, editors, text search).
+  A 2 MB thread document is always a 2 MB thread document, not a shell of
+  pointers into blob storage.
+- Consumers must understand two storage surfaces instead of one. The
+  blob-vs-inline boundary is documented in [reference/02][ref-02] and hinges on
+  a single criterion: file bytes live in blobs, everything else lives inline.
+
+## More Information
+
+- [Original design conversation, Turns 7–8 — Format and the medallion
+  model][turns-7-8]
+- [Reference/02 — directory structure][ref-02] for the on-disk layout of the
+  blob store
+- [N-03: Code Snapshot Preservation][n03] — consumer of this decision
+
+[turns-7-8]: ../reference/00-original-conversation.md#turn-7-8-format-and-the-medallion-model
+[ref-02]: ../reference/02-directory-structure.md
+[n03]: ../needs/N-03-code-snapshot-preservation.md

--- a/docs/decisions/D-05-patch-files-are-not-json.md
+++ b/docs/decisions/D-05-patch-files-are-not-json.md
@@ -1,0 +1,66 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-05: Patch files are not JSON
+
+## Context and Problem Statement
+
+The archive contains diffs of several sizes and shapes: small hunks quoted as
+context on a single thread, round-level diffs spanning a handful of files, and
+full between-snapshot diffs that can run into thousands of lines. Every diff has
+an established native representation (unified format) that existing tools
+understand. The archive must decide whether to embed diffs as strings inside
+JSON documents or to store them as standalone `.patch` files alongside the JSON.
+
+## Considered Options
+
+- **Embed in JSON.** Every diff is a string field on the JSON record that
+  contains it; the archive has one storage surface fewer to document.
+- **Standalone `.patch` files.** Diffs are written to their own files under
+  `diffs/` in unified format; JSON records reference them by path.
+
+## Decision Outcome
+
+Chosen option: _standalone `.patch` files_, because the unified diff format is
+already the lingua franca for diffs and pushing it through JSON escaping breaks
+everything that expects to read patches with standard tooling. `git apply`,
+`patch`, IDE diff viewers, and code-review tools all consume `.patch` files
+directly; requiring consumers to unescape JSON strings before using any of them
+is a cost paid on every interaction.
+
+Embedded diffs also degrade the JSON files that carry them. A single
+thousand-line diff turns a navigable JSON document into one with a single
+multi-kilobyte string field, which `jq`, editors, and version-control diffing
+handle poorly.
+
+## Consequences
+
+- Diffs compress well and remain human-readable in the archive. A reader (or
+  reviewer, or tool) can `cat` a `.patch` file and understand it without
+  interpretation.
+- The archive has two storage surfaces besides blobs — JSON and patches — but
+  the split is sharply defined by file extension, so consumers know where to
+  look.
+- Thread and comment records can still carry short hunk context inline (per
+  [D-03][d-03]) because those excerpts are small, navigable, and pattern-matched
+  rather than tool-applied. The full patch lives in `diffs/` for consumers that
+  need to apply or render it.
+- Diffs are not content-addressed because they are comparatively small and do
+  not deduplicate the way file contents do. The blob/patch split therefore
+  matches what each format is best at: blobs for dedupable bytes, patches for
+  tool-native diffs.
+
+## More Information
+
+- [Reference/02 — directory structure][ref-02] for the on-disk layout of
+  `diffs/`
+- [D-03: Data duplication over normalization][d-03] — why short hunks still
+  appear inline inside thread and comment records
+- [D-04: Blobs for file contents, inline for everything else][d-04] — the
+  sibling format-matching decision for file bytes
+
+[ref-02]: ../reference/02-directory-structure.md
+[d-03]: D-03-data-duplication-over-normalization.md
+[d-04]: D-04-blobs-for-file-contents.md

--- a/docs/decisions/D-06-single-pr-atomic-unit.md
+++ b/docs/decisions/D-06-single-pr-atomic-unit.md
@@ -1,0 +1,72 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-06: Single-PR export as the atomic unit
+
+## Context and Problem Statement
+
+The long-term goal is to capture a team's review practices across many PRs, but
+every aggregated export starts from individual PRs. Two paths are natural: treat
+the archive as repo-level from day one (one big directory, shared blob store,
+shared thread index), or treat each PR as its own independent archive and add
+batching later. The choice shapes how the prototype ships, how failures
+propagate, and how later workflows evolve.
+
+The target user settled this at [Turns 7–8][turns-7-8] of the 3–4 April 2026
+design conversation, in the same exchange that established the
+directory-tree-with-content-addressed-blobs format: "start with one independent
+directory per PR, add a merge command later."
+
+## Considered Options
+
+- **Repo-level atomicity from the start.** One archive per repository; shared
+  blob store and shared indexes span all PRs. Cross-PR deduplication comes for
+  free, but every export coordinates with the shared state.
+- **Per-PR atomicity.** Each PR exports to a fully independent directory. No
+  shared state across PRs. Cross-PR deduplication deferred to a merge command.
+
+## Decision Outcome
+
+Chosen option: _per-PR atomicity_, because the prototype needs to ship one PR at
+a time, and a failure on PR 37 should not invalidate the work already done on
+PRs 1–36. Independence makes partial exports, retries, and cherry-picking
+individual PR archives trivial. The efficiency concerns that motivate repo-level
+atomicity (shared blob store, repo-wide indexes) can be reclaimed later by a
+merge step without paying for them upfront.
+
+## Consequences
+
+- The v1 output is a self-contained directory per PR. This is what
+  [W-02a: multi-PR export][w02a] operates on — a simple loop over PRs, each
+  producing an independent archive, with no coordination between invocations.
+- [W-02b: merge into repo-batch format][w02b] is the planned path to reclaim
+  cross-PR deduplication and shared indexes. Its design can proceed on its own
+  schedule because nothing about v1 commits to a final aggregated shape.
+- Per-PR atomicity pulls the blob store inside each PR's directory as well, so
+  the archive travels as a unit. That corollary has its own record as the
+  per-PR-blob-scope decision.
+- Initial storage is less efficient than a repo-level archive would be (a file
+  present in ten PRs is stored ten times in v1). The cost is accepted as a
+  prototype concession, addressable by merge.
+- Several fields in the v1 schema (`version.json` format tag, `exported_at`
+  timestamp, directory layout under `prs/`) are motivated by future batch
+  workflows even though v1 exports single PRs. The
+  [relationship-to-v1 table in W-02][w02-v1] lists them explicitly.
+
+## More Information
+
+- [Original design conversation, Turns 7–8 — Format and the medallion
+  model][turns-7-8]
+- [W-02: Batch and Merge][w02] — the workflow family that consumes this
+  decision, with [W-02a][w02a] relying on per-PR atomicity and [W-02b][w02b]
+  introducing merge
+- [Relationship to V1 table in W-02][w02-v1] — concrete list of v1 choices
+  motivated by batch workflows
+
+[turns-7-8]: ../reference/00-original-conversation.md#turn-7-8-format-and-the-medallion-model
+[w02]: ../conops/W-02-batch-and-merge.md
+[w02a]: ../conops/W-02-batch-and-merge.md#w-02a-multi-pr-export
+[w02b]: ../conops/W-02-batch-and-merge.md#w-02b-merge-into-repo-batch-format
+[w02-v1]: ../conops/W-02-batch-and-merge.md#relationship-to-v1

--- a/docs/decisions/D-07-dual-body-md-and-html.md
+++ b/docs/decisions/D-07-dual-body-md-and-html.md
@@ -1,0 +1,66 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-07: Both markdown body and HTML body
+
+## Context and Problem Statement
+
+Every comment, review, and PR description in GitHub has two canonical
+representations: the raw markdown the author typed, and the HTML GitHub renders
+server-side. Those are not the same text. GitHub's renderer understands
+extensions that plain CommonMark does not — suggestion blocks, formatted tables,
+autolinked references, emoji shortcodes, `@`-mentions resolved to profile links
+— so the HTML is often the only faithful record of what the reviewer actually
+saw. Conversely, the raw markdown is what training pipelines and silver-tier
+transformations expect to consume. The archive has to pick which to preserve on
+every body-bearing record.
+
+## Considered Options
+
+- **Raw markdown only.** Store `body`; leave rendering to consumers.
+- **HTML only.** Store `body_html`; discard the original markdown in favour of
+  the rendered form.
+- **Store both.** Keep `body` and `body_html` on every record that has a body.
+
+## Decision Outcome
+
+Chosen option: _store both_, because neither representation subsumes the other.
+GitHub-rendered HTML carries information that cannot be reconstructed from the
+markdown without replicating GitHub's renderer (with its evolving extensions and
+repo-specific context); raw markdown carries authorial intent that cannot be
+reconstructed from HTML without heuristic de-rendering. Storing both lets
+consumers choose based on what they are doing — markdown for training-example
+construction, HTML for faithful replay and UI reconstruction — without forcing
+either to synthesise the other.
+
+## Consequences
+
+- Every body-carrying record in the schema — PR description, review summary,
+  thread comment, review comment — exposes two fields: `body` for markdown,
+  `body_html` for rendered HTML. This shape is visible in the concrete payloads
+  in [reference/03][ref-03].
+- Archive size grows modestly per comment. The overhead is a roughly constant
+  factor over storing one form; text bodies are small compared to file contents,
+  so the cost sits far below the blob store in the storage budget.
+- Visualisation consumers (e.g., the playground named in the mission) can
+  reproduce what the reviewer saw pixel-for-pixel without calling GitHub. That
+  is part of what makes the archive [self-contained][sc].
+- Training consumers that want only markdown can ignore `body_html` entirely.
+  The decision does not impose a format on them; it just ensures the HTML is
+  there when needed.
+- GitHub's renderer output is GitHub-version-specific. The HTML captured at
+  export time is a snapshot of that rendering; if a consumer needs rendering
+  from a different GitHub vintage, a silver-tier transform can re-render the
+  markdown with an alternative pipeline.
+
+## More Information
+
+- [Reference/03 — schema specification][ref-03] for the `body` / `body_html`
+  field layout across record types
+- [Mission success criterion 4][sc] — self-containment is what motivates keeping
+  the HTML alongside the markdown
+
+[ref-03]: ../reference/03-schema-specification.md
+[sc]: ../mission.md#success-criteria

--- a/docs/decisions/D-08-precomputed-thread-indexes.md
+++ b/docs/decisions/D-08-precomputed-thread-indexes.md
@@ -1,0 +1,73 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-08: Indexes in threads.json are precomputed conveniences
+
+## Context and Problem Statement
+
+Threads are the most access-diverse payload in the archive. Different consumers
+want to slice them along different axes: a "render this file" view needs threads
+keyed by file path; a "reconstruct this round" view needs threads keyed by
+round; a resolution analysis needs threads keyed by `is_resolved`. A single
+container shape can only be cheap along one axis; any other grouping forces a
+full scan.
+
+The question surfaced at [Turn 10][turn-10] of the 3–4 April 2026 design
+conversation, when the target user pushed back on an earlier draft that keyed
+`threads.json` by file path: "the threads file should not be keyed by file,
+rather have an index that shows different groupings."
+
+## Considered Options
+
+- **Key threads by file path.** `threads["path/to/file"]` gives fast file-scoped
+  access; every other grouping requires iteration.
+- **Key threads by round.** Round-scoped access is fast; file and resolution
+  groupings require iteration.
+- **Flat array with precomputed indexes.** Threads live in a single ordered
+  list; an `indexes` object alongside it holds secondary maps (`by_file`,
+  `by_round`, `by_resolution`) that project the list by each access axis.
+
+## Decision Outcome
+
+Chosen option: _flat array with precomputed indexes_, because privileging any
+one axis forces every other consumer to reimplement the same scans the exporter
+already has the data to compute once. Indexes are cheap to build at export time
+(the exporter already holds the full thread list in memory), trivial to
+validate, and free for consumers to use. The flat array keeps the canonical
+representation stable while the index set is allowed to grow.
+
+## Consequences
+
+- `threads.json` has two top-level shapes: a flat `threads` array that carries
+  the canonical records, and an `indexes` object that projects that array by
+  file, by round, and by resolution state. Consumers pick the shape that suits
+  their access pattern without re-scanning.
+- Schema evolution of the index set is additive. A new index type (e.g.,
+  `by_author`) appears alongside the existing ones without breaking consumers
+  that already use `by_file` — this matches the schema-evolution principle
+  [N-10][n10] asks the archive to satisfy.
+- Index entries hold thread IDs, not inlined thread bodies, so the index cost is
+  small relative to the thread payload it points into. Consumers de-reference
+  IDs against the flat list when they need bodies.
+- The flat array remains the source of truth; indexes are a derived view. If the
+  two ever disagree, the flat array wins. A consumer that distrusts an index can
+  always rebuild it from the list.
+- The reference payloads in [reference/03][ref-03] show the `indexes` object
+  concretely and document the three index types shipped in v1.
+
+## More Information
+
+- [Original design conversation, Turn 10 — Final corrections][turn-10]
+- [Reference/03 — schema specification][ref-03] for the `threads.json` top-level
+  shape
+- [N-02: Thread Capture][n02] — the need that makes thread access a first-class
+  consumer concern
+- [N-10: Schema Evolution][n10] — why the index set can grow without breaking
+  consumers
+
+[turn-10]: ../reference/00-original-conversation.md#turn-10-final-corrections
+[ref-03]: ../reference/03-schema-specification.md
+[n02]: ../needs/N-02-thread-capture.md
+[n10]: ../needs/N-10-schema-evolution.md

--- a/docs/decisions/D-09-per-pr-blob-scope.md
+++ b/docs/decisions/D-09-per-pr-blob-scope.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-09: Per-PR blob scope, not cross-repo
+
+## Context and Problem Statement
+
+Once the archive externalises file bytes to a content-addressed blob store
+([D-04][d-04]), the next question is where that store lives. A repo-wide blob
+store shared by all PRs maximises deduplication: a file present in ten PRs is
+stored once. A per-PR blob store forfeits that deduplication but keeps each PR
+archive self-contained — the PR directory can be copied, shared, or deleted
+without touching anything outside it. The choice has to cooperate with the
+per-PR atomicity the single-PR export decision already commits to.
+
+## Considered Options
+
+- **Shared repo-wide blob store from day one.** One blob directory for the whole
+  repository; every PR export writes into and reads from it. Cross-PR
+  deduplication is automatic.
+- **Per-PR blob store; merge command promotes blobs later.** Each PR's archive
+  holds its own blob store under its own directory. A later merge step (W-02b)
+  promotes blobs to a shared store when combining archives into `repo-batch`
+  format.
+
+## Decision Outcome
+
+Chosen option: _per-PR blob store_, because it keeps per-PR atomicity honest.
+[D-06][d-06] commits to each PR archive being independent — movable,
+restartable, deletable on its own — and a shared blob store would either break
+that property or require coordination with state outside the PR directory. The
+storage cost of duplicated blobs is accepted as the v1 concession, reclaimed at
+merge time rather than paid up front.
+
+## Consequences
+
+- Every PR archive is truly self-contained. Moving, archiving, or deleting a PR
+  directory does not affect any other PR. The
+  [self-containment success criterion][sc] holds at the PR boundary without
+  caveats.
+- A file that appears in ten PRs is stored ten times in v1. The cost is bounded
+  by how similar the affected files are across PRs and is recovered by
+  [W-02b: merge into repo-batch format][w02b], which promotes blobs to a shared
+  store once archives are combined.
+- The merge command's value is sharpened by this decision: without cross-PR blob
+  scope in v1, deduplication _is_ what W-02b provides, not a detail of it. That
+  clarifies the v1-to-batch transition.
+- Consumers can reason about blob lifetimes one PR at a time. There is no global
+  garbage collection concern, no cross-archive reference tracking, no migration
+  path to worry about when a single PR is re-exported.
+
+## More Information
+
+- [D-04: Blobs for file contents, inline for everything else][d-04] — the
+  decision that establishes the blob store this one scopes
+- [D-06: Single-PR export as the atomic unit][d-06] — the parent decision this
+  one makes operational for blob storage
+- [W-02b: merge into repo-batch format][w02b] — where cross-PR deduplication
+  lands
+- [Mission success criterion 4][sc] — the self-containment property per-PR scope
+  preserves
+
+[d-04]: D-04-blobs-for-file-contents.md
+[d-06]: D-06-single-pr-atomic-unit.md
+[w02b]: ../conops/W-02-batch-and-merge.md#w-02b-merge-into-repo-batch-format
+[sc]: ../mission.md#success-criteria

--- a/docs/decisions/D-10-context-files-same-package.md
+++ b/docs/decisions/D-10-context-files-same-package.md
@@ -1,0 +1,77 @@
+---
+status: accepted
+date: 2026-04-21
+---
+
+# D-10: Context files scoped to same package/directory
+
+## Context and Problem Statement
+
+A review comment on a single file is rarely understandable on that file alone.
+The reviewer's concern lives in a neighbourhood of declarations: types defined
+in sibling files, constants the changed code references, helpers it calls into.
+The archive therefore has to capture unchanged "context files" alongside the
+PR-affected ones. What is too little context collapses downstream replay; what
+is too much burns API quota on every round (snapshot fetching is the most
+expensive phase of the export). The decision draws the default line.
+
+## Considered Options
+
+- **No context.** Store only PR-affected files. Smallest archive, cheapest API
+  usage, poorest comprehensibility for any reviewer or model consuming the
+  archive.
+- **Same-directory default, language-aware.** For Go repos, context means all
+  `.go` files in the directory (i.e., the package). For other languages, the
+  same directory is the default. Configurable to widen or narrow.
+- **Broader context (imports, transitive).** Follow import edges to pull the
+  files a changed file depends on. Most comprehensible, most expensive, and most
+  language-dependent to implement robustly.
+
+## Decision Outcome
+
+Chosen option: _same-directory default, language-aware_, because it matches the
+unit of meaning in most ecosystems (a directory is a package in Go, a module in
+many others) and sets a cost ceiling that scales with the number of rounds
+rather than with the repository's import graph. The scope is configurable so
+users working in languages or conventions where the default is wrong can widen
+or narrow it without editing the tool.
+
+Every context file carries a `reason` field recording why it was included, so
+consumers can distinguish same-package defaults from user-configured additions.
+
+## Consequences
+
+- Snapshot fetching is the archive's dominant API cost; the same-directory
+  default caps that cost at "directory size × rounds" rather than letting
+  import-chasing explode it. This is the efficiency promise [N-07][n07] rests
+  on.
+- Go gets a natural default because "same directory" and "same package"
+  coincide, matching how Go programmers already reason about compilation units.
+  Other languages inherit the fallback and pay the cost of its looseness; the
+  configurability hatch covers the cases where the fallback misleads.
+- The `reason` field makes the context set auditable. A reader of the archive
+  can tell which files were pulled in by default and which by configuration,
+  which is particularly valuable when the archive is shared with a downstream
+  consumer who didn't run the export.
+- Context scoping interacts with [N-03][n03] (snapshot preservation): each
+  round's snapshot lists both the changed files and the context files with their
+  respective blob SHAs. The blob store ([D-04][d-04]) deduplicates across rounds
+  automatically, so stable context files pay once even when they appear in every
+  snapshot.
+- This decision is explicitly the v1 default. A follow-up analysis (planned as
+  A-02 in the analysis phase of the SE documentation) will evaluate whether
+  language-specific defaults beyond Go should ship with the tool and what a more
+  sophisticated context-selection algorithm would offer.
+
+## More Information
+
+- [Reference/04 — API mapping][ref-04] for the context-fetching API pattern
+- [N-03: Code Snapshot Preservation][n03] — the need that consumes this decision
+- [N-07: API Efficiency][n07] — the cost ceiling same-directory defaults respect
+- [D-04: Blobs for file contents, inline for everything else][d-04] — why stable
+  context files pay their storage cost only once
+
+[ref-04]: ../reference/04-api-mapping.md
+[n03]: ../needs/N-03-code-snapshot-preservation.md
+[n07]: ../needs/N-07-api-efficiency.md
+[d-04]: D-04-blobs-for-file-contents.md

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,37 @@
+# Decision Records
+
+Records in this directory use [MADR] format. Conventions specific to this
+project are below.
+
+## Frontmatter
+
+```yaml
+---
+status: accepted
+date: 2026-04-21
+---
+```
+
+- `status` — one of `proposed`, `accepted`, `deprecated`, `superseded`,
+  `rejected`.
+- `date` — ISO-8601 `YYYY-MM-DD`; the date of the current status, not the date
+  the record was created.
+- `superseded-by` — required when and only when `status: superseded`. Its value
+  is the `D-nn` ID of the replacement. Supersessors cross-link back in their own
+  `## More Information`; the superseded record keeps its body so the history
+  stays readable.
+
+## Filename and ID
+
+- Kebab-case with a `D-nn` prefix, e.g., `D-01-threads-belong-to-rounds.md`.
+- `D-nn` is a flat, zero-padded two-digit sequence. IDs are never reused, even
+  for rejected or superseded records.
+- This README is intentionally unnumbered so existing `D-01`..`D-10` citations
+  in committed artifacts stay valid.
+
+## Links
+
+Ref-style links targeting the most specific anchor available, per the SE docs'
+house rule.
+
+[MADR]: https://adr.github.io/madr/

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -19,15 +19,16 @@ includes the document where it is first defined or most fully described.
 
 ## Data Architecture Terms
 
-| Term                          | Definition                                                                                                               | Origin                             |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
-| **Bronze tier**               | Raw exported data with no analysis, inference, or transformation. First stage of the Medallion model.                    | [reference/01][ref-01] §Purpose    |
-| **Medallion model**           | A data architecture pattern organizing data into bronze (raw), silver (cleaned/structured), and gold (aggregated) tiers. | [reference/01][ref-01] §Purpose    |
-| **Export archive**            | The self-contained directory tree produced by a single export run, containing all JSON, patch, and blob files.           | [reference/02][ref-02] §Layout     |
-| **Content-addressed storage** | File storage keyed by git blob SHA, enabling natural deduplication when the same file appears across multiple snapshots. | [reference/02][ref-02] §Blobs      |
-| **Target user perspective**   | The organizing principle of the export: rounds, threads, and gaps are defined relative to the target user's activity.    | [reference/05][ref-05] §Decision 1 |
+| Term                          | Definition                                                                                                               | Origin                          |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| **Bronze tier**               | Raw exported data with no analysis, inference, or transformation. First stage of the Medallion model.                    | [reference/01][ref-01] §Purpose |
+| **Medallion model**           | A data architecture pattern organizing data into bronze (raw), silver (cleaned/structured), and gold (aggregated) tiers. | [reference/01][ref-01] §Purpose |
+| **Export archive**            | The self-contained directory tree produced by a single export run, containing all JSON, patch, and blob files.           | [reference/02][ref-02] §Layout  |
+| **Content-addressed storage** | File storage keyed by git blob SHA, enabling natural deduplication when the same file appears across multiple snapshots. | [reference/02][ref-02] §Blobs   |
+| **Target user perspective**   | The organizing principle of the export: rounds, threads, and gaps are defined relative to the target user's activity.    | [D-01][d-01]                    |
 
 [ref-01]: reference/01-design-overview.md
 [ref-02]: reference/02-directory-structure.md
 [ref-04]: reference/04-api-mapping.md
 [ref-05]: reference/05-glossary-and-decisions.md
+[d-01]: decisions/D-01-threads-belong-to-rounds.md

--- a/docs/needs/N-02-thread-capture.md
+++ b/docs/needs/N-02-thread-capture.md
@@ -45,7 +45,7 @@ The need is met when, for a given PR:
 - Each thread carries GitHub's resolution signals verbatim; the archive contains
   no field that infers _why_ the thread was resolved, ignored, or left open.
 
-[d-01]: ../reference/05-glossary-and-decisions.md#1-threads-belong-to-rounds-comments-dont
+[d-01]: ../decisions/D-01-threads-belong-to-rounds.md
 [d-02]: ../reference/05-glossary-and-decisions.md#2-no-inference-at-export-time
 [w01-thread]: ../conops/W-01-single-pr-export.md#thread-capture
 [sc]: ../mission.md#success-criteria

--- a/docs/needs/N-02-thread-capture.md
+++ b/docs/needs/N-02-thread-capture.md
@@ -46,6 +46,6 @@ The need is met when, for a given PR:
   no field that infers _why_ the thread was resolved, ignored, or left open.
 
 [d-01]: ../decisions/D-01-threads-belong-to-rounds.md
-[d-02]: ../reference/05-glossary-and-decisions.md#2-no-inference-at-export-time
+[d-02]: ../decisions/D-02-no-inference-at-export-time.md
 [w01-thread]: ../conops/W-01-single-pr-export.md#thread-capture
 [sc]: ../mission.md#success-criteria

--- a/docs/reference/00-original-conversation.md
+++ b/docs/reference/00-original-conversation.md
@@ -107,8 +107,8 @@ produced design decision D-02 (no inference at export time) in
 
 A targeted structural correction: the round association belongs on the
 **thread**, not on individual comments. A thread is born in a round; the
-conversation under it is timeless. This became design decision D-01 (threads
-belong to rounds, comments don't) in [reference/05][ref-05].
+conversation under it is timeless. This became design decision
+[D-01 (threads belong to rounds, comments don't)][d-01].
 
 ### Turn 7-8: Format and the medallion model
 
@@ -170,7 +170,7 @@ How the conversation shaped the systems engineering artifacts:
 | Playground test (turn 4)          | [mission.md](../mission.md) — success criteria; [actors](../conops/actors.md) — visualization consumer |
 | Export not analysis (turn 4)      | [mission.md](../mission.md) — scope boundaries                                                         |
 | Thread realism (turn 5)           | D-02 — no inference at export time                                                                     |
-| Thread-round association (turn 6) | D-01 — threads belong to rounds                                                                        |
+| Thread-round association (turn 6) | [D-01][d-01] — threads belong to rounds                                                                |
 | Medallion model (turn 8)          | [mission.md](../mission.md) — data architecture position                                               |
 | Per-PR isolation (turn 8)         | D-06 — single-PR atomic unit; [W-02](../conops/W-02-batch-and-merge.md)                                |
 | File splitting rationale (turn 9) | [reference/02][ref-02] — directory structure                                                           |
@@ -180,3 +180,4 @@ How the conversation shaped the systems engineering artifacts:
 [ref-02]: 02-directory-structure.md
 [ref-05]: 05-glossary-and-decisions.md
 [n09]: ../needs/N-09-target-user-perspective.md
+[d-01]: ../decisions/D-01-threads-belong-to-rounds.md

--- a/docs/reference/00-original-conversation.md
+++ b/docs/reference/00-original-conversation.md
@@ -121,8 +121,8 @@ the project within the medallion model: bronze (raw export) → silver (structur
 training examples) → gold (agent quality metrics).
 
 The user also established the **per-PR isolation** strategy: start with one
-independent directory per PR, add a merge command later. This became D-06
-(single-PR export as atomic unit) and shaped
+independent directory per PR, add a merge command later. This became
+[D-06 (single-PR export as atomic unit)][d-06] and shaped
 [W-02](../conops/W-02-batch-and-merge.md).
 
 ### Turn 9: File splitting
@@ -172,7 +172,7 @@ How the conversation shaped the systems engineering artifacts:
 | Thread realism (turn 5)           | [D-02][d-02] — no inference at export time                                                             |
 | Thread-round association (turn 6) | [D-01][d-01] — threads belong to rounds                                                                |
 | Medallion model (turn 8)          | [mission.md](../mission.md) — data architecture position                                               |
-| Per-PR isolation (turn 8)         | D-06 — single-PR atomic unit; [W-02](../conops/W-02-batch-and-merge.md)                                |
+| Per-PR isolation (turn 8)         | [D-06][d-06] — single-PR atomic unit; [W-02](../conops/W-02-batch-and-merge.md)                        |
 | File splitting rationale (turn 9) | [reference/02][ref-02] — directory structure                                                           |
 | Precomputed indexes (turn 10)     | D-08 — indexes in threads.json                                                                         |
 
@@ -182,3 +182,4 @@ How the conversation shaped the systems engineering artifacts:
 [n09]: ../needs/N-09-target-user-perspective.md
 [d-01]: ../decisions/D-01-threads-belong-to-rounds.md
 [d-02]: ../decisions/D-02-no-inference-at-export-time.md
+[d-06]: ../decisions/D-06-single-pr-atomic-unit.md

--- a/docs/reference/00-original-conversation.md
+++ b/docs/reference/00-original-conversation.md
@@ -96,9 +96,9 @@ success criterion in [mission.md](../mission.md) and motivated the
 The user pushed back on Claude's thread resolution inference. Claude's thinking
 block acknowledged: "I'm over-engineering the thread structure by trying to
 infer semantics from data that's inherently noisy and incomplete." This directly
-produced design decision D-02 (no inference at export time) in
-[reference/05][ref-05]: capture only what GitHub's API returns (`is_resolved`,
-`is_outdated`), leave interpretation to the analysis layer.
+produced design decision [D-02 (no inference at export time)][d-02]: capture
+only what GitHub's API returns (`is_resolved`, `is_outdated`), leave
+interpretation to the analysis layer.
 
 ### Turn 6: Thread-round association
 
@@ -169,7 +169,7 @@ How the conversation shaped the systems engineering artifacts:
 | "Giving in" pattern (turn 3)      | [N-09][n09] — target user perspective                                                                  |
 | Playground test (turn 4)          | [mission.md](../mission.md) — success criteria; [actors](../conops/actors.md) — visualization consumer |
 | Export not analysis (turn 4)      | [mission.md](../mission.md) — scope boundaries                                                         |
-| Thread realism (turn 5)           | D-02 — no inference at export time                                                                     |
+| Thread realism (turn 5)           | [D-02][d-02] — no inference at export time                                                             |
 | Thread-round association (turn 6) | [D-01][d-01] — threads belong to rounds                                                                |
 | Medallion model (turn 8)          | [mission.md](../mission.md) — data architecture position                                               |
 | Per-PR isolation (turn 8)         | D-06 — single-PR atomic unit; [W-02](../conops/W-02-batch-and-merge.md)                                |
@@ -181,3 +181,4 @@ How the conversation shaped the systems engineering artifacts:
 [ref-05]: 05-glossary-and-decisions.md
 [n09]: ../needs/N-09-target-user-perspective.md
 [d-01]: ../decisions/D-01-threads-belong-to-rounds.md
+[d-02]: ../decisions/D-02-no-inference-at-export-time.md

--- a/docs/reference/00-original-conversation.md
+++ b/docs/reference/00-original-conversation.md
@@ -174,7 +174,7 @@ How the conversation shaped the systems engineering artifacts:
 | Medallion model (turn 8)          | [mission.md](../mission.md) — data architecture position                                               |
 | Per-PR isolation (turn 8)         | [D-06][d-06] — single-PR atomic unit; [W-02](../conops/W-02-batch-and-merge.md)                        |
 | File splitting rationale (turn 9) | [reference/02][ref-02] — directory structure                                                           |
-| Precomputed indexes (turn 10)     | D-08 — indexes in threads.json                                                                         |
+| Precomputed indexes (turn 10)     | [D-08][d-08] — indexes in threads.json                                                                 |
 
 [ref-01]: 01-design-overview.md
 [ref-02]: 02-directory-structure.md
@@ -183,3 +183,4 @@ How the conversation shaped the systems engineering artifacts:
 [d-01]: ../decisions/D-01-threads-belong-to-rounds.md
 [d-02]: ../decisions/D-02-no-inference-at-export-time.md
 [d-06]: ../decisions/D-06-single-pr-atomic-unit.md
+[d-08]: ../decisions/D-08-precomputed-thread-indexes.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -33,6 +33,8 @@ without fixing, ignore threads, have verbal conversations outside GitHub. The
 export captures only what GitHub's API returns (`is_resolved`, `is_outdated`).
 Analysis tooling fills in the rest later.
 
+Formalized as [D-02][d-02].
+
 ### 3. Data duplication over normalization
 
 The same diff hunk may appear on a thread's `original_diff_hunk`, on each
@@ -89,3 +91,4 @@ API-wise and should be configurable. The `reason` field on context files
 documents why each was included.
 
 [d-01]: ../decisions/D-01-threads-belong-to-rounds.md
+[d-02]: ../decisions/D-02-no-inference-at-export-time.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -77,6 +77,8 @@ suggestion blocks, formatted tables, and other GitHub-specific markdown
 extensions that may look different from raw markdown. Both are stored to give
 consumers the choice.
 
+Formalized as [D-07][d-07].
+
 ### 8. Indexes in threads.json are precomputed conveniences
 
 The `indexes` object in `threads.json` groups thread IDs by file, round, and
@@ -104,3 +106,4 @@ documents why each was included.
 [d-04]: ../decisions/D-04-blobs-for-file-contents.md
 [d-05]: ../decisions/D-05-patch-files-are-not-json.md
 [d-06]: ../decisions/D-06-single-pr-atomic-unit.md
+[d-07]: ../decisions/D-07-dual-body-md-and-html.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -68,6 +68,8 @@ Each PR exports to a fully independent directory. No shared state across PRs.
 This simplifies the prototype, makes partial exports and retries trivial, and
 the merge command handles batching later.
 
+Formalized as [D-06][d-06].
+
 ### 7. Both markdown body and HTML body
 
 GitHub renders markdown server-side. The HTML version preserves rendered
@@ -101,3 +103,4 @@ documents why each was included.
 [d-03]: ../decisions/D-03-data-duplication-over-normalization.md
 [d-04]: ../decisions/D-04-blobs-for-file-contents.md
 [d-05]: ../decisions/D-05-patch-files-are-not-json.md
+[d-06]: ../decisions/D-06-single-pr-atomic-unit.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -95,6 +95,8 @@ to the merge command, which promotes blobs to a shared store when combining
 exports into `repo-batch` format. This keeps each export self-contained and
 moveable.
 
+Formalized as [D-09][d-09].
+
 ### 10. Context files scoped to same package/directory
 
 For Go repos, context means all `.go` files in the same directory (package). For
@@ -110,3 +112,4 @@ documents why each was included.
 [d-06]: ../decisions/D-06-single-pr-atomic-unit.md
 [d-07]: ../decisions/D-07-dual-body-md-and-html.md
 [d-08]: ../decisions/D-08-precomputed-thread-indexes.md
+[d-09]: ../decisions/D-09-per-pr-blob-scope.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -86,6 +86,8 @@ resolution status. These are cheap to compute at export time and save consumers
 from scanning the full thread list. New index types can be added in future
 schema versions without breaking existing data.
 
+Formalized as [D-08][d-08].
+
 ### 9. Per-PR blob scope, not cross-repo
 
 Blobs are stored within each PR's directory. Cross-PR deduplication is deferred
@@ -107,3 +109,4 @@ documents why each was included.
 [d-05]: ../decisions/D-05-patch-files-are-not-json.md
 [d-06]: ../decisions/D-06-single-pr-atomic-unit.md
 [d-07]: ../decisions/D-07-dual-body-md-and-html.md
+[d-08]: ../decisions/D-08-precomputed-thread-indexes.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -42,6 +42,8 @@ comment's `diff_hunk_at_time`, and in a patch file under `diffs/`. This is
 intentional — each location serves a different access pattern, and consumers
 shouldn't need to cross-reference files for basic operations.
 
+Formalized as [D-03][d-03].
+
 ### 4. Blobs for file contents, inline for everything else
 
 File contents are the only data externalized to the blob store. Diffs, comments,
@@ -92,3 +94,4 @@ documents why each was included.
 
 [d-01]: ../decisions/D-01-threads-belong-to-rounds.md
 [d-02]: ../decisions/D-02-no-inference-at-export-time.md
+[d-03]: ../decisions/D-03-data-duplication-over-normalization.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -51,6 +51,8 @@ metadata, and thread conversations stay in their respective JSON files. The
 split is driven by deduplication potential (high for file contents, low for
 everything else) and size (file contents dominate storage).
 
+Formalized as [D-04][d-04].
+
 ### 5. Patch files are not JSON
 
 Diffs are stored as plain `.patch` files in unified diff format. They're an
@@ -95,3 +97,4 @@ documents why each was included.
 [d-01]: ../decisions/D-01-threads-belong-to-rounds.md
 [d-02]: ../decisions/D-02-no-inference-at-export-time.md
 [d-03]: ../decisions/D-03-data-duplication-over-normalization.md
+[d-04]: ../decisions/D-04-blobs-for-file-contents.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -104,6 +104,8 @@ other languages, same directory is the default. This is the most expensive part
 API-wise and should be configurable. The `reason` field on context files
 documents why each was included.
 
+Formalized as [D-10][d-10].
+
 [d-01]: ../decisions/D-01-threads-belong-to-rounds.md
 [d-02]: ../decisions/D-02-no-inference-at-export-time.md
 [d-03]: ../decisions/D-03-data-duplication-over-normalization.md
@@ -113,3 +115,4 @@ documents why each was included.
 [d-07]: ../decisions/D-07-dual-body-md-and-html.md
 [d-08]: ../decisions/D-08-precomputed-thread-indexes.md
 [d-09]: ../decisions/D-09-per-pr-blob-scope.md
+[d-10]: ../decisions/D-10-context-files-same-package.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -60,6 +60,8 @@ established format with native tool support, they compress well, and embedding
 large diffs in JSON adds escaping overhead and makes the JSON files hard to
 navigate.
 
+Formalized as [D-05][d-05].
+
 ### 6. Single-PR export as the atomic unit
 
 Each PR exports to a fully independent directory. No shared state across PRs.
@@ -98,3 +100,4 @@ documents why each was included.
 [d-02]: ../decisions/D-02-no-inference-at-export-time.md
 [d-03]: ../decisions/D-03-data-duplication-over-normalization.md
 [d-04]: ../decisions/D-04-blobs-for-file-contents.md
+[d-05]: ../decisions/D-05-patch-files-are-not-json.md

--- a/docs/reference/05-glossary-and-decisions.md
+++ b/docs/reference/05-glossary-and-decisions.md
@@ -23,6 +23,8 @@ conversation under the thread is timeless; individual comments don't carry round
 associations. This avoids misattributing replies and developer responses to
 reviewer rounds they weren't part of.
 
+Formalized as [D-01][d-01].
+
 ### 2. No inference at export time
 
 Fields like `resolution_type` exist as placeholders (`null`) but are never
@@ -85,3 +87,5 @@ For Go repos, context means all `.go` files in the same directory (package). For
 other languages, same directory is the default. This is the most expensive part
 API-wise and should be configurable. The `reason` field on context files
 documents why each was included.
+
+[d-01]: ../decisions/D-01-threads-belong-to-rounds.md


### PR DESCRIPTION
The SE scaffold's `docs/README.md` advertised a `decisions/` directory with the `D-nn` ID scheme, and reading-order step 6 sent readers there — but the directory held only `.gitkeep`. Meanwhile, `N-02: Thread Capture`, the influence map in the original-conversation distillation, and the glossary's "target user perspective" entry already cited `D-01`, `D-02`, `D-06`, and `D-08` by ID via anchors into `reference/05`. Every decision citation resolved to a header inside a reference archive rather than to a canonical record. This PR lands Phase 5.1 of `PLAN.md`: the ten reference/05 decisions now exist as formal MADR records under `docs/decisions/`, and the dangling citations point at those records.

MADR was chosen so each record carries a YAML-parseable lifecycle (`status`, `date`, `superseded-by`) rather than encoding status in prose. The format convention lives in `docs/decisions/README.md` and is intentionally unnumbered so the already-committed `D-01`..`D-10` citations stay valid.

Reference/05 is prior work and the archive of record for the original decision phrasing, so each per-decision commit leaves its subsection body intact and only appends a `Formalized as [D-nn][d-nn].` pointer with a ref-style link definition. Citations in N-02, the original-conversation distillation, and the glossary are retargeted to the canonical files inside the same commit that creates each decision.

`D-11`..`D-14` are out of scope; they wait for Phase 5.2, which depends on the `A-01`..`A-04` analyses that the SE documentation has not yet drafted. Phase 3 (requirements) is untouched.

PLAN.md had Phase 3 as "Next" before this PR; the Progress section now records that Phase 5.1 landed ahead of Phase 3 because resolving the dangling citations was worth doing before further SE work stacks on top of the reference/05 anchors.